### PR TITLE
add --fix to no-identical-tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Name | ✔️ | 🛠 | Description
 [prefer-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-placeholders.md) | | | Disallows template literals as report messages
 [no-useless-token-range](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-useless-token-range.md) | ✔️ | 🛠 | Disallows unnecessary calls to sourceCode.getFirstToken and sourceCode.getLastToken
 [consistent-output](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/consistent-output.md) | | | Enforces consistent use of output assertions in rule tests
-[no-identical-tests](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-identical-tests.md) | | | Disallows identical tests
+[no-identical-tests](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-identical-tests.md) | | 🛠 | Disallows identical tests
 
 ## Supported Presets
 

--- a/docs/rules/no-identical-tests.md
+++ b/docs/rules/no-identical-tests.md
@@ -1,5 +1,7 @@
 # Disallow identical tests (no-identical-tests)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 When a rule has a lot of tests, it's sometimes difficult to tell if any tests are duplicates. This rule would warn if any test cases have the same properties.
 
 ## Rule Details

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -42,7 +42,12 @@ module.exports = {
                   node: test,
                   message,
                   fix (fixer) {
-                    return fixer.remove(test);
+                    const start = sourceCode.getTokenBefore(test);
+                    const end = sourceCode.getTokenAfter(test);
+                    return fixer.replaceTextRange(
+                      // should remove test's trailing comma
+                      [start.range[1], end.range[end.value === ',' ? 1 : 0]]
+                      , '');
                   },
                 });
               } else {

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -46,7 +46,7 @@ module.exports = {
                     const end = sourceCode.getTokenAfter(test);
                     return fixer.replaceTextRange(
                       // should remove test's trailing comma
-                      [start.range[1], end.range[end.value === ',' ? 1 : 0]]
+                      [start.range[1], end.value === ',' ? end.range[1] : test.range[1]]
                       , '');
                   },
                 });

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -44,10 +44,9 @@ module.exports = {
                   fix (fixer) {
                     const start = sourceCode.getTokenBefore(test);
                     const end = sourceCode.getTokenAfter(test);
-                    return fixer.replaceTextRange(
+                    return fixer.removeRange(
                       // should remove test's trailing comma
-                      [start.range[1], end.value === ',' ? end.range[1] : test.range[1]]
-                      , '');
+                      [start.range[1], end.value === ',' ? end.range[1] : test.range[1]]);
                   },
                 });
               } else {

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -18,7 +18,7 @@ module.exports = {
       category: 'Tests',
       recommended: false,
     },
-    fixable: null,  // or "code" or "whitespace"
+    fixable: 'code',
     schema: [],
   },
 
@@ -41,6 +41,9 @@ module.exports = {
                 context.report({
                   node: test,
                   message,
+                  fix (fixer) {
+                    return fixer.remove(test);
+                  },
                 });
               } else {
                 cache[testCode] = true;

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -25,7 +25,7 @@ ruleTester.run('no-identical-tests', rule, {
       new RuleTester().run('foo', bar, {
         valid: [
           { code: 'foo' },
-          { code: 'bar' }
+          { code: 'bar' },
         ],
         invalid: []
       });
@@ -48,6 +48,7 @@ ruleTester.run('no-identical-tests', rule, {
         new RuleTester().run('foo', bar, {
           valid: [
             { code: 'foo' },
+            ,
           ],
           invalid: []
         });
@@ -71,9 +72,11 @@ ruleTester.run('no-identical-tests', rule, {
         new RuleTester().run('foo', bar, {
           valid: [
             { code: 'foo' },
+            ,
           ],
           invalid: [
             { code: 'foo', errors: ['bar'] },
+            ,
           ]
         });
       `,

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -38,12 +38,20 @@ ruleTester.run('no-identical-tests', rule, {
         new RuleTester().run('foo', bar, {
           valid: [
             { code: 'foo' },
-            { code: 'foo' }
+            { code: 'foo' },
           ],
           invalid: []
         });
       `,
       errors: [ERROR],
+      output: `
+        new RuleTester().run('foo', bar, {
+          valid: [
+            { code: 'foo' },
+          ],
+          invalid: []
+        });
+      `,
     },
     {
       code: `
@@ -59,6 +67,16 @@ ruleTester.run('no-identical-tests', rule, {
         });
       `,
       errors: [ERROR, ERROR],
+      output: `
+        new RuleTester().run('foo', bar, {
+          valid: [
+            { code: 'foo' },
+          ],
+          invalid: [
+            { code: 'foo', errors: ['bar'] },
+          ]
+        });
+      `,
     },
   ],
 });

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -30,6 +30,14 @@ ruleTester.run('no-identical-tests', rule, {
         invalid: []
       });
     `,
+    `
+      new RuleTester().run('foo', bar, {
+        valid: [
+          { code: 'foo' }
+        ],
+        invalid: []
+      });
+    `,
   ],
 
   invalid: [
@@ -39,6 +47,26 @@ ruleTester.run('no-identical-tests', rule, {
           valid: [
             { code: 'foo' },
             { code: 'foo' },
+          ],
+          invalid: []
+        });
+      `,
+      errors: [ERROR],
+      output: `
+        new RuleTester().run('foo', bar, {
+          valid: [
+            { code: 'foo' },
+          ],
+          invalid: []
+        });
+      `,
+    },
+    {
+      code: `
+        new RuleTester().run('foo', bar, {
+          valid: [
+            { code: 'foo' },
+            { code: 'foo' }
           ],
           invalid: []
         });

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -48,7 +48,6 @@ ruleTester.run('no-identical-tests', rule, {
         new RuleTester().run('foo', bar, {
           valid: [
             { code: 'foo' },
-            ,
           ],
           invalid: []
         });
@@ -72,11 +71,9 @@ ruleTester.run('no-identical-tests', rule, {
         new RuleTester().run('foo', bar, {
           valid: [
             { code: 'foo' },
-            ,
           ],
           invalid: [
             { code: 'foo', errors: ['bar'] },
-            ,
           ]
         });
       `,


### PR DESCRIPTION
<del>this is WIP, as the trailing commas have not been handled.</del>

it simply remove the identical tests, so may cause incorrect indent. any suggestions? @not-an-aardvark 