### PR TITLE
Fix: some rules crash if tests array has missing elements (fixes #35).

### DIFF
--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -37,6 +37,11 @@ module.exports = {
      *@returns {boolean} if eq, return true, else return false.
     */
     function eq (testA, testB) {
+      // https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/35
+      if (!testA || !testB) {
+        return testA === testB;
+      }
+
       if (testA.type !== testB.type) {
         return false;
       }

--- a/lib/rules/test-case-property-ordering.js
+++ b/lib/rules/test-case-property-ordering.js
@@ -38,7 +38,7 @@ module.exports = {
         utils.getTestInfo(context, ast).forEach(testRun => {
           [testRun.valid, testRun.invalid].forEach(tests => {
             (tests || []).forEach(test => {
-              const properties = test.properties || [];
+              const properties = (test && test.properties) || [];
               const keyNames = properties.map(utils.getKeyName);
 
               for (let i = 0, lastChecked; i < keyNames.length; i++) {

--- a/lib/rules/test-case-shorthand-strings.js
+++ b/lib/rules/test-case-shorthand-strings.js
@@ -37,15 +37,17 @@ module.exports = {
     */
     function reportTestCases (cases) {
       const caseInfoList = cases.map(testCase => {
-        if (testCase.type === 'Literal' || testCase.type === 'TemplateLiteral') {
-          return { node: testCase, shorthand: true, needsLongform: false };
-        }
-        if (testCase.type === 'ObjectExpression') {
-          return {
-            node: testCase,
-            shorthand: false,
-            needsLongform: !(testCase.properties.length === 1 && utils.getKeyName(testCase.properties[0]) === 'code'),
-          };
+        if (testCase) {
+          if (testCase.type === 'Literal' || testCase.type === 'TemplateLiteral') {
+            return { node: testCase, shorthand: true, needsLongform: false };
+          }
+          if (testCase.type === 'ObjectExpression') {
+            return {
+              node: testCase,
+              shorthand: false,
+              needsLongform: !(testCase.properties.length === 1 && utils.getKeyName(testCase.properties[0]) === 'code'),
+            };
+          }
         }
         return null;
       }).filter(Boolean);


### PR DESCRIPTION
rules: no-identical-tests, test-case-property-ordering, test-case-shorthand-string.