### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Enforce consistent use of output assertions in rule tests',
       category: 'Tests',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/consistent-output.md',
     },
     fixable: null, // or "code" or "whitespace"
     schema: [],

--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -21,6 +21,7 @@ module.exports = {
       description: 'Expected fixer function to always return a value.',
       category: 'Possible Errors',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/fixer-return.md',
     },
     fixable: null,
   },

--- a/lib/rules/no-deprecated-context-methods.js
+++ b/lib/rules/no-deprecated-context-methods.js
@@ -40,6 +40,7 @@ module.exports = {
       description: 'Disallows usage of deprecated methods on rule context objects',
       category: 'Rules',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-deprecated-context-methods.md',
     },
     fixable: 'code',
     schema: [],

--- a/lib/rules/no-deprecated-report-api.js
+++ b/lib/rules/no-deprecated-report-api.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'disallow use of the deprecated context.report() API',
       category: 'Rules',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-deprecated-report-api.md',
     },
     fixable: 'code', // or "code" or "whitespace"
     schema: [],

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'disallow identical tests',
       category: 'Tests',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-identical-tests.md',
     },
     fixable: 'code',
     schema: [],

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Disallow missing placeholders in rule report messages',
       category: 'Rules',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-missing-placeholders.md',
     },
     fixable: null,
     schema: [],

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Disallow unused placeholders in rule report messages',
       category: 'Rules',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-unused-placeholders.md',
     },
     fixable: null,
     schema: [],

--- a/lib/rules/no-useless-token-range.js
+++ b/lib/rules/no-useless-token-range.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Disallow unnecessary calls to sourceCode.getFirstToken and sourceCode.getLastToken',
       category: 'Rules',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/no-useless-token-range.md',
     },
     fixable: 'code',
     schema: [],

--- a/lib/rules/prefer-output-null.js
+++ b/lib/rules/prefer-output-null.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'disallows invalid RuleTester test cases with the output the same as the code.',
       category: 'Tests',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/prefer-output-null.md',
     },
     fixable: 'code',
     schema: [],

--- a/lib/rules/prefer-placeholders.js
+++ b/lib/rules/prefer-placeholders.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'disallow template literals as report messages',
       category: 'Rules',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/prefer-placeholders.md',
     },
     fixable: null,
     schema: [],

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'prefer using replaceText instead of replaceTextRange.',
       category: 'Rules',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/prefer-replace-text.md',
     },
     fixable: null,
     schema: [],

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'enforce a consistent format for rule report messages',
       category: 'Rules',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/report-message-format.md',
     },
     fixable: null,
     schema: [

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'require rules to implement a meta.fixable property',
       category: 'Rules',
       recommended: true,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/require-meta-fixable.md',
     },
     schema: [],
   },

--- a/lib/rules/test-case-property-ordering.js
+++ b/lib/rules/test-case-property-ordering.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Requires the properties of a test case to be placed in a consistent order',
       category: 'Tests',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/test-case-property-ordering.md',
     },
     fixable: 'code',
     schema: [{

--- a/lib/rules/test-case-shorthand-strings.js
+++ b/lib/rules/test-case-shorthand-strings.js
@@ -17,6 +17,7 @@ module.exports = {
       description: 'Enforce consistent usage of shorthand strings for test cases with no options',
       category: 'Tests',
       recommended: false,
+      url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/master/docs/rules/test-case-shorthand-strings.md',
     },
     schema: [{ enum: ['as-needed', 'never', 'consistent', 'consistent-as-needed'] }],
     fixable: 'code',


### PR DESCRIPTION
 ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.