### PR TITLE
WIP: Add require-valid-categories rule

### DIFF
--- a/lib/rules/require-valid-categories.js
+++ b/lib/rules/require-valid-categories.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const utils = require('../utils');
+
+module.exports = {
+  meta: {
+    docs: {},
+    category: '', // fixme: add valid category
+    schema: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+      uniqueItems: true,
+    },
+  },
+  create (context) {
+    const options = new Set(context.options || []);
+
+    // fixme: add JSDoc
+    function isValidCategory (node) {
+      return Boolean(
+        node &&
+        node.type === 'Literal' &&
+        typeof node.value === 'string' &&
+        options.has(node.value)
+      );
+    }
+
+    return {
+      Program (node) {
+        const info = utils.getRuleInfo(node);
+        if (!info) {
+          return;
+        }
+
+        const metaNode = info.meta;
+        const docsPropNode =
+          metaNode &&
+          metaNode.properties &&
+          metaNode.properties.find(p => p.type === 'Property' && utils.getKeyName(p) === 'docs');
+        const categoryPropNode =
+          docsPropNode &&
+          docsPropNode.value.properties &&
+          docsPropNode.value.properties.find(p => p.type === 'Property' && utils.getKeyName(p) === 'category');
+
+        if (isValidCategory(categoryPropNode && categoryPropNode.value)) {
+          return;
+        }
+
+        context.report({
+          node: categoryPropNode.value,
+          message: 'Not a valid category.',
+        });
+      },
+    };
+  },
+};

--- a/tests/lib/rules/require-valid-categories.js
+++ b/tests/lib/rules/require-valid-categories.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/require-valid-categories');
+const RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+
+ruleTester.run('require-valid-categories', rule, {
+  valid: [
+    {
+      code: `
+module.exports = {
+  meta: {
+    docs: {
+      category: "Possible Errors"
+    }
+  },
+  create(context) {
+    return {}
+  }
+}
+`,
+      options: ['Possible Errors'],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+module.exports = {
+  meta: {
+    docs: {
+      category: "Stylistic Issues"
+    }
+  },
+  create(context) {
+    return {}
+  }
+}
+`,
+      options: ['Possible Errors'],
+      errors: [
+        { message: 'Not a valid category.' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
See #60 

This is a start at implementing the rule in #60. Still a WIP, but wanted to open the PR to start a discussion and also let you know that someone is working on it. 🎉 

TODO: 

- [ ] add rule category
- [ ] add proper JSDoc
- [ ] add more test cases (old rule format, new rule format, empty category option, no category option, invalid category option, like numbers)
- [ ] add `docs/rules/require-valid-categories.md`