### PR TITLE
Update: ensure report-message-format checks formatting in meta.messages

### DIFF
--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -28,6 +28,24 @@ module.exports = {
     const pattern = new RegExp(context.options[0] || '');
     let contextIdentifiers;
 
+    /**
+     * Report a message node if it doesn't match the given formatting
+     * @param {ASTNode} message The message AST node
+     * @returns {void}
+     */
+    function processMessageNode (message) {
+      if (
+        (message.type === 'Literal' && typeof message.value === 'string' && !pattern.test(message.value)) ||
+        (message.type === 'TemplateLiteral' && message.quasis.length === 1 && !pattern.test(message.quasis[0].value.cooked))
+      ) {
+        context.report({
+          node: message,
+          message: "Report message does not match the pattern '{{pattern}}'.",
+          data: { pattern: context.options[0] || '' },
+        });
+      }
+    }
+
     // ----------------------------------------------------------------------
     // Public
     // ----------------------------------------------------------------------
@@ -35,6 +53,20 @@ module.exports = {
     return {
       Program (node) {
         contextIdentifiers = utils.getContextIdentifiers(context, node);
+        const ruleInfo = utils.getRuleInfo(context.getSourceCode().ast);
+        const messagesObject = ruleInfo &&
+          ruleInfo.meta &&
+          ruleInfo.meta.type === 'ObjectExpression' &&
+          ruleInfo.meta.properties.find(prop => prop.type === 'Property' && utils.getKeyName(prop) === 'messages');
+
+        if (!messagesObject || messagesObject.value.type !== 'ObjectExpression') {
+          return;
+        }
+
+        messagesObject.value.properties
+          .filter(prop => prop.type === 'Property')
+          .map(prop => prop.value)
+          .forEach(processMessageNode);
       },
       CallExpression (node) {
         if (
@@ -49,16 +81,7 @@ module.exports = {
             return;
           }
 
-          if (
-            (message.type === 'Literal' && typeof message.value === 'string' && !pattern.test(message.value)) ||
-            (message.type === 'TemplateLiteral' && message.quasis.length === 1 && !pattern.test(message.quasis[0].value.cooked))
-          ) {
-            context.report({
-              node: message,
-              message: "Report message does not match the pattern '{{pattern}}'.",
-              data: { pattern: context.options[0] || '' },
-            });
-          }
+          processMessageNode(message);
         }
       },
     };

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -113,6 +113,20 @@ ruleTester.run('report-message-format', rule, {
       `,
       options: ['foo'],
     },
+    {
+      code: `
+        module.exports = {
+          meta: {
+            messages: {
+              message1: 'foo bar',
+              message2: 'bar foobar'
+            }
+          },
+          create: context => ({})
+        }
+      `,
+      options: ['foo'],
+    },
   ],
 
   invalid: [
@@ -172,6 +186,19 @@ ruleTester.run('report-message-format', rule, {
           create(context) {
             context.report({node, message: \`FOO\`});
           }
+        };
+      `,
+      options: ['foo'],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: {
+            messages: {
+              message1: 'bar'
+            }
+          },
+          create: context => ({})
         };
       `,
       options: ['foo'],


### PR DESCRIPTION
This fixes a bug where `report-message-format` wouldn't check message specified in `meta.messages`, so if a rule was using `messageId`s it could inadvertently use messages that don't match the required format.

I originally noticed this bug in https://github.com/eslint/eslint/pull/11033#discussion_r239992302.