### PR TITLE
Update: add plugins in configs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ module.exports.rules = allRules;
 module.exports.configs = Object.keys(configFilters).reduce((configs, configName) => {
   return Object.assign(configs, {
     [configName]: {
+      plugins: ['eslint-plugin'],
       rules: Object.keys(allRules)
         .filter(ruleName => configFilters[configName](allRules[ruleName]))
         .reduce((rules, ruleName) => Object.assign(rules, { [`${PLUGIN_NAME}/${ruleName}`]: 'error' }), {}),


### PR DESCRIPTION
it aims to simplify usage of the plugin (so users no need to specify it).
but the tests failed, as eslint cannot find `eslint-plugin-eslint-plugin` when linting the repo. any ideas?