### PR TITLE
Add `always` option to `consistent-output` rule

### DIFF
--- a/docs/rules/consistent-output.md
+++ b/docs/rules/consistent-output.md
@@ -56,6 +56,13 @@ new RuleTester().run('example-rule', rule, {
 
 ```
 
+## Options
+
+This rule takes an optional string enum option with one of the following values:
+
+* `"consistent"` - (default) if any invalid test cases have output assertions, then all invalid test cases must have output assertions
+* `"always"` - always require invalid test cases to have output assertions
+
 ## When Not To Use It
 
 If you're not writing fixable rules, or you want to write test cases without output assertions, do not enable this rule.

--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -20,13 +20,19 @@ module.exports = {
     },
     type: 'suggestion',
     fixable: null, // or "code" or "whitespace"
-    schema: [],
+    schema: [
+      {
+        type: 'string',
+        enum: ['always', 'consistent'],
+      },
+    ],
   },
 
   create (context) {
     // ----------------------------------------------------------------------
     // Public
     // ----------------------------------------------------------------------
+    const always = context.options[0] && context.options[0] === 'always';
 
     return {
       Program (ast) {
@@ -35,7 +41,10 @@ module.exports = {
           const casesWithoutOutput = readableCases
             .filter(testCase => testCase.properties.map(utils.getKeyName).indexOf('output') === -1);
 
-          if (casesWithoutOutput.length < readableCases.length) {
+          if (
+            (casesWithoutOutput.length < readableCases.length) ||
+            (always && casesWithoutOutput.length > 0)
+          ) {
             casesWithoutOutput.forEach(testCase => {
               context.report({
                 node: testCase,

--- a/tests/lib/rules/consistent-output.js
+++ b/tests/lib/rules/consistent-output.js
@@ -53,6 +53,21 @@ ruleTester.run('consistent-output', rule, {
         ]
       });
     `,
+    {
+      code: `
+        new RuleTester().run('foo', bar, {
+          valid: [],
+          invalid: [
+            {
+              code: 'foo',
+              output: 'baz',
+              errors: ['bar']
+            },
+          ]
+        });
+      `,
+      options: ['always'],
+    },
   ],
 
   invalid: [
@@ -78,6 +93,21 @@ ruleTester.run('consistent-output', rule, {
         });
       `,
       errors: [ERROR, ERROR],
+    },
+    {
+      code: `
+        new RuleTester().run('foo', bar, {
+          valid: [],
+          invalid: [
+            {
+              code: 'foo',
+              errors: ['bar'],
+            },
+          ]
+        });
+      `,
+      options: ['always'],
+      errors: [ERROR],
     },
   ],
 });


### PR DESCRIPTION
I'd like to ensure that invalid test cases always assert what the output should be.

The existing behavior of the rule is not very useful to me, since contributors of new rules often forget about or are unaware of the "output" assertion, and thus leave it out entirely, which the rule does not warn about.