### PR TITLE
Update `require-meta-schema` rule to allow object schemas (in addition to array schemas)

### DIFF
--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -28,7 +28,7 @@ module.exports = {
     ],
     messages: {
       missing: '`meta.schema` is required (use [] if rule has no schema).',
-      wrongType: '`meta.schema` should be an array (use [] if rule has no schema).',
+      wrongType: '`meta.schema` should be an array or object (use [] if rule has no schema).',
     },
   },
 
@@ -56,7 +56,7 @@ module.exports = {
               return utils.insertProperty(fixer, metaNode, 'schema: []', sourceCode);
             },
           });
-        } else if (schemaNode.value.type !== 'ArrayExpression') {
+        } else if (!['ArrayExpression', 'ObjectExpression'].includes(schemaNode.value.type)) {
           context.report({ node: schemaNode.value, messageId: 'wrongType' });
         }
       },

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -26,6 +26,12 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) {}
       };
     `,
+    `
+      module.exports = {
+        meta: { schema: { "enum": ["always", "never"] } },
+        create(context) {}
+      };
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Turns out that eslint supports both array and object schemas. eslint itself has a handful of rules that use objects schemas, although array schemas are much more common.

https://eslint.org/docs/developer-guide/working-with-rules#options-schemas

Example rule with object schema: https://github.com/eslint/eslint/blob/master/lib/rules/eqeqeq.js#L29
Example rule with array schema: https://github.com/eslint/eslint/blob/master/lib/rules/func-style.js#L22