### PR TITLE
add the plugin name to plugins prop of presets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ module.exports.rules = allRules;
 module.exports.configs = Object.keys(configFilters).reduce((configs, configName) => {
   return Object.assign(configs, {
     [configName]: {
+      plugins: ['eslint-plugin'],
       rules: Object.keys(allRules)
         .filter(ruleName => configFilters[configName](allRules[ruleName]))
         .reduce((rules, ruleName) => Object.assign(rules, { [`${PLUGIN_NAME}/${ruleName}`]: 'error' }), {}),


### PR DESCRIPTION
This will make no needs to add `eslint-plugin` to `plugins` manually if a preset is enabled.