### PR TITLE
Fix: Rule can't find reference of `create` function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,12 +37,13 @@ function isNormalFunctionExpressionReference (node, scopeManager) {
     const found = currentScope.references.find(reference => {
       return reference.resolved && reference.identifier === node;
     });
+
     if (found) {
       createReference = found;
       break;
-    } else {
-      scopes.push(...currentScope.childScopes);
     }
+
+    scopes.push(...currentScope.childScopes);
   }
 
   if (!createReference) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,16 +30,22 @@ function isNormalFunctionExpressionReference (node, scopeManager) {
   }
 
   const scope = scopeManager.acquire(node) || scopeManager.globalScope;
-  if (!scope) {
-    return false;
+  const scopes = [scope];
+  let createReference;
+  while (scopes.length > 0) {
+    const currentScope = scopes.shift();
+    const found = currentScope.references.find(reference => {
+      return reference.resolved && reference.identifier === node;
+    });
+    if (found) {
+      createReference = found;
+      break;
+    } else {
+      scopes.push(...currentScope.childScopes);
+    }
   }
 
-  const references = scope.references;
-  const createReference = references.find(reference => {
-    return reference.identifier === node;
-  });
-
-  if (!createReference || !createReference.resolved) {
+  if (!createReference) {
     return false;
   }
 

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -122,6 +122,31 @@ describe('utils', () => {
           );
         });
       });
+
+      for (const scopeOptions of [
+        { ignoreEval: true, ecmaVersion: 6, sourceType: 'script', nodejsScope: true },
+        { ignoreEval: true, ecmaVersion: 6, sourceType: 'script' },
+        { ignoreEval: true, ecmaVersion: 6, sourceType: 'module' },
+      ]) {
+        const ast = espree.parse(`
+          const create = () => {};
+          const meta = {};
+          module.exports = { create, meta };
+        `, { ecmaVersion: 6 });
+        const expected = {
+          create: { type: 'Identifier' },
+          meta: { type: 'Identifier' },
+          isNewStyle: true,
+        };
+        it(`ScopeOptions: ${JSON.stringify(scopeOptions)}`, () => {
+          const scope = escope.analyze(ast, scopeOptions);
+          const ruleInfo = utils.getRuleInfo(ast, scope);
+          assert(
+            lodash.isMatch(ruleInfo, expected),
+            `Expected \n${util.inspect(ruleInfo)}\nto match\n${util.inspect(expected)}`
+          );
+        });
+      }
     });
   });
 


### PR DESCRIPTION
Turns out if `create` is a reference, the global scope don't have the reference not only in `nodejsScope`, also broken if `sourceType` is set to `'module'`.

To find the correct reference, I'm searching all `childScopes`, I hope it's fine to do this.

Fixes #106