### PR TITLE
Improve detection of static `description` strings and ignore non-static descriptions in `require-meta-docs-description` rule

### DIFF
--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { getStaticValue } = require('eslint-utils');
 const utils = require('../utils');
 
 // ------------------------------------------------------------------------------
@@ -7,16 +8,6 @@ const utils = require('../utils');
 // ------------------------------------------------------------------------------
 
 const DEFAULT_PATTERN = new RegExp('^(enforce|require|disallow)');
-
-/**
- * Whether or not the node is a string literal
- *
- * @param {object} node
- * @returns {boolean} whether or not the node is a string literal
- */
-function isStringLiteral (node) {
-  return node.type === 'Literal' && typeof node.value === 'string';
-}
 
 module.exports = {
   meta: {
@@ -70,11 +61,20 @@ module.exports = {
 
         if (!descriptionNode) {
           context.report({ node: docsNode ? docsNode : metaNode, messageId: 'missing' });
-        } else if (!isStringLiteral(descriptionNode.value) || descriptionNode.value.value === '') {
+          return;
+        }
+
+        const staticValue = getStaticValue(descriptionNode.value, context.getScope());
+        if (!staticValue) {
+          // Ignore non-static values since we can't determine what they look like.
+          return;
+        }
+
+        if (typeof staticValue.value !== 'string' || staticValue.value === '') {
           context.report({ node: descriptionNode.value, messageId: 'wrongType' });
-        } else if (descriptionNode.value.value !== descriptionNode.value.value.trim()) {
+        } else if (staticValue.value !== staticValue.value.trim()) {
           context.report({ node: descriptionNode.value, messageId: 'extraWhitespace' });
-        } else if (!pattern.test(descriptionNode.value.value)) {
+        } else if (!pattern.test(staticValue.value)) {
           context.report({
             node: descriptionNode.value,
             message: '`meta.docs.description` must match the regexp {{pattern}}.',

--- a/tests/lib/rules/require-meta-docs-description.js
+++ b/tests/lib/rules/require-meta-docs-description.js
@@ -32,6 +32,44 @@ ruleTester.run('require-meta-docs-description', rule, {
         create(context) {}
       };
     `,
+    `
+      module.exports = {
+        meta: { docs: { description: generateRestOfDescription() } },
+        create(context) {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: { description: \`enforce with template literal\` } },
+        create(context) {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: { description: "enforce" + " " + "something" } },
+        create(context) {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: { description: "enforce " + generateSomething() } },
+        create(context) {}
+      };
+    `,
+    `
+      const DESCRIPTION = 'require foo';
+      module.exports = {
+        meta: { docs: { description: DESCRIPTION } },
+        create(context) {}
+      };
+    `,
+    `
+      const DESCRIPTION = generateDescription();
+      module.exports = {
+        meta: { docs: { description: DESCRIPTION } },
+        create(context) {}
+      };
+    `,
     {
       code:
         `
@@ -88,17 +126,18 @@ ruleTester.run('require-meta-docs-description', rule, {
     {
       code: `
         module.exports = {
-          meta: { docs: { description: \`enforce with template literal\` } },
+          meta: { docs: { description: '' } },
           create(context) {}
         };
       `,
       output: null,
-      errors: [{ messageId: 'wrongType', type: 'TemplateLiteral' }],
+      errors: [{ messageId: 'wrongType', type: 'Literal' }],
     },
     {
       code: `
+        const DESCRIPTION = true;
         module.exports = {
-          meta: { docs: { description: SOME_DESCRIPTION } },
+          meta: { docs: { description: DESCRIPTION } },
           create(context) {}
         };
       `,
@@ -107,13 +146,14 @@ ruleTester.run('require-meta-docs-description', rule, {
     },
     {
       code: `
+        const DESCRIPTION = 123;
         module.exports = {
-          meta: { docs: { description: '' } },
+          meta: { docs: { description: DESCRIPTION } },
           create(context) {}
         };
       `,
       output: null,
-      errors: [{ messageId: 'wrongType', type: 'Literal' }],
+      errors: [{ messageId: 'wrongType', type: 'Identifier' }],
     },
     {
       code: `
@@ -134,6 +174,16 @@ ruleTester.run('require-meta-docs-description', rule, {
       `,
       output: null,
       errors: [{ message: '`meta.docs.description` must match the regexp /^(enforce|require|disallow)/.', type: 'Literal' }],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { docs: { description: 'foo' + ' ' + 'bar' } },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ message: '`meta.docs.description` must match the regexp /^(enforce|require|disallow)/.', type: 'BinaryExpression' }],
     },
     {
       code: `


### PR DESCRIPTION
Two changes:
* Drastically improves detection of the `description` string value when it can be determined statically, including handling when the description is stored in a constant or created through string concatenation
* If we cannot determine the string value of the `description` statically, then bail out and report no violations, so that users can dynamically generate the description if they'd like to

Fixes #97.