### PR TITLE
Breaking: Add `meta.hasSuggestions` property to `meta-property-ordering` rule

### DIFF
--- a/docs/rules/meta-property-ordering.md
+++ b/docs/rules/meta-property-ordering.md
@@ -10,7 +10,7 @@ This rule enforces that meta properties of a rule are placed in a consistent ord
 
 This rule has an array option:
 
-* `['type', 'docs', 'fixable', 'schema', 'messages', 'deprecated', 'replacedBy']` (default): The order that the properties of `meta` should be placed in.
+* `['type', 'docs', 'fixable', 'hasSuggestions', 'schema', 'messages', 'deprecated', 'replacedBy']` (default): The order that the properties of `meta` should be placed in.
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -32,7 +32,7 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const info = getRuleInfo(sourceCode);
 
-    const order = context.options[0] || ['type', 'docs', 'fixable', 'schema', 'messages'];
+    const order = context.options[0] || ['type', 'docs', 'fixable', 'hasSuggestions', 'schema', 'messages'];
 
     const orderMap = new Map(order.map((name, i) => [name, i]));
 

--- a/lib/rules/no-only-tests.js
+++ b/lib/rules/no-only-tests.js
@@ -11,13 +11,13 @@ module.exports = {
       category: 'Tests',
       recommended: false,
     },
+    hasSuggestions: true,
     schema: [],
     messages: {
       foundOnly:
         'The test case property `only` can be used during development, but should not be checked-in, since it prevents all the tests from running.',
       removeOnly: 'Remove `only`.',
     },
-    hasSuggestions: true,
   },
 
   create (context) {

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -15,6 +15,7 @@ module.exports = {
       category: 'Rules',
       recommended: false, // TODO: enable it in a major release.
     },
+    hasSuggestions: true,
     schema: [
       {
         type: 'object',
@@ -33,7 +34,6 @@ module.exports = {
       missing: '`meta.schema` is required (use [] if rule has no schema).',
       wrongType: '`meta.schema` should be an array or object (use [] if rule has no schema).',
     },
-    hasSuggestions: true,
   },
 
   create (context) {

--- a/tests/lib/rules/meta-property-ordering.js
+++ b/tests/lib/rules/meta-property-ordering.js
@@ -42,6 +42,7 @@ ruleTester.run('test-case-property-ordering', rule, {
         type: 'problem',
         docs: {},
         fixable: 'code',
+        hasSuggestions: true,
         schema: [],
         messages: {}
       },


### PR DESCRIPTION
It makes most sense to order the new ESLint 8 property `meta.hasSuggestions` (whether a rule provides suggestions) after the related property `meta.fixable` (whether a rule is autofixable).

https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#rules-with-suggestions-now-require-the-metahassuggestions-property