### PR TITLE
Mention allowed `type` values in `require-meta-type` rule doc

### DIFF
--- a/docs/rules/require-meta-type.md
+++ b/docs/rules/require-meta-type.md
@@ -6,7 +6,11 @@ Fixes in custom rules will not be applied when using `--fix-type` unless they in
 
 ## Rule Details
 
-This rule aims to require ESLint rules to have a valid `meta.type` property.
+This rule aims to require ESLint rules to have a valid `meta.type` property with one of the following values:
+
+* `"problem"` means the rule is identifying code that either will cause an error or may cause a confusing behavior. Developers should consider this a high priority to resolve.
+* `"suggestion"` means the rule is identifying something that could be done in a better way but no errors will occur if the code isn't changed.
+* `"layout"` means the rule cares primarily about whitespace, semicolons, commas, and parentheses, all the parts of the program that determine how the code looks rather than how it executes. These rules work on parts of the code that aren't specified in the AST.
 
 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
The list and explanations come from: https://eslint.org/docs/developer-guide/working-with-rules#rule-basics