### PR TITLE
Improve detection of static arguments of `context.report()` in several rules

### DIFF
--- a/lib/rules/no-deprecated-report-api.js
+++ b/lib/rules/no-deprecated-report-api.js
@@ -48,7 +48,7 @@ module.exports = {
             fix (fixer) {
               const openingParen = sourceCode.getTokenBefore(node.arguments[0]);
               const closingParen = sourceCode.getLastToken(node);
-              const reportInfo = utils.getReportInfo(node.arguments);
+              const reportInfo = utils.getReportInfo(node.arguments, context);
 
               if (!reportInfo) {
                 return null;

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const utils = require('../utils');
+const { getStaticValue } = require('eslint-utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -40,13 +41,17 @@ module.exports = {
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' && node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node.arguments);
+          const reportInfo = utils.getReportInfo(node.arguments, context);
+          if (!reportInfo || !reportInfo.message) {
+            return;
+          }
 
+          const messageStaticValue = getStaticValue(reportInfo.message, context.getScope());
           if (
-            reportInfo &&
-            reportInfo.message &&
-            reportInfo.message.type === 'Literal' &&
-            typeof reportInfo.message.value === 'string' &&
+            (
+              (reportInfo.message.type === 'Literal' && typeof reportInfo.message.value === 'string') ||
+              (messageStaticValue && typeof messageStaticValue.value === 'string')
+            ) &&
             (!reportInfo.data || reportInfo.data.type === 'ObjectExpression')
           ) {
             // Same regex as the one ESLint uses
@@ -54,7 +59,7 @@ module.exports = {
             const PLACEHOLDER_MATCHER = /\{\{\s*([^{}]+?)\s*\}\}/g;
             let match;
 
-            while ((match = PLACEHOLDER_MATCHER.exec(reportInfo.message.value))) { // eslint-disable-line no-extra-parens
+            while ((match = PLACEHOLDER_MATCHER.exec(reportInfo.message.value || messageStaticValue.value))) { // eslint-disable-line no-extra-parens
               const matchingProperty = reportInfo.data &&
                 reportInfo.data.properties.find(prop => utils.getKeyName(prop) === match[1]);
 

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const utils = require('../utils');
+const { getStaticValue } = require('eslint-utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -40,16 +41,21 @@ module.exports = {
             contextIdentifiers.has(node.callee.object) &&
             node.callee.property.type === 'Identifier' && node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node.arguments);
+          const reportInfo = utils.getReportInfo(node.arguments, context);
+          if (!reportInfo || !reportInfo.message) {
+            return;
+          }
 
+          const messageStaticValue = getStaticValue(reportInfo.message, context.getScope());
           if (
-            reportInfo &&
-                reportInfo.message &&
-                reportInfo.message.type === 'Literal' &&
-                typeof reportInfo.message.value === 'string' &&
-              reportInfo.data && reportInfo.data.type === 'ObjectExpression'
+            (
+              (reportInfo.message.type === 'Literal' && typeof reportInfo.message.value === 'string') ||
+              (messageStaticValue && typeof messageStaticValue.value === 'string')
+            ) &&
+            reportInfo.data &&
+            reportInfo.data.type === 'ObjectExpression'
           ) {
-            const message = reportInfo.message.value;
+            const message = reportInfo.message.value || messageStaticValue.value;
             // https://github.com/eslint/eslint/blob/2874d75ed8decf363006db25aac2d5f8991bd969/lib/linter.js#L986
             const PLACEHOLDER_MATCHER = /\{\{\s*([^{}]+?)\s*\}\}/g;
             const placeholdersInMessage = new Set();

--- a/lib/rules/prefer-placeholders.js
+++ b/lib/rules/prefer-placeholders.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const utils = require('../utils');
+const { findVariable } = require('eslint-utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -26,6 +27,9 @@ module.exports = {
   create (context) {
     let contextIdentifiers;
 
+    const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     // ----------------------------------------------------------------------
     // Public
     // ----------------------------------------------------------------------
@@ -40,16 +44,42 @@ module.exports = {
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' && node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node.arguments);
+          const reportInfo = utils.getReportInfo(node.arguments, context);
+
+          if (!reportInfo || !reportInfo.message) {
+            return;
+          }
+
+          let messageNode = reportInfo.message;
+
+          if (messageNode.type === 'Identifier') {
+            // See if we can find the variable declaration.
+
+            const variable = findVariable(
+              scopeManager.acquire(messageNode) || scopeManager.globalScope,
+              messageNode
+            );
+
+            if (
+              !variable ||
+              !variable.defs ||
+              !variable.defs[0] ||
+              !variable.defs[0].node ||
+              variable.defs[0].node.type !== 'VariableDeclarator' ||
+              !variable.defs[0].node.init
+            ) {
+              return;
+            }
+
+            messageNode = variable.defs[0].node.init;
+          }
 
           if (
-            reportInfo && reportInfo.message && (
-              (reportInfo.message.type === 'TemplateLiteral' && reportInfo.message.expressions.length) ||
-              (reportInfo.message.type === 'BinaryExpression' && reportInfo.message.operator === '+')
-            )
+            (messageNode.type === 'TemplateLiteral' && messageNode.expressions.length) ||
+            (messageNode.type === 'BinaryExpression' && messageNode.operator === '+')
           ) {
             context.report({
-              node: reportInfo.message,
+              node: messageNode,
               message: 'Use report message placeholders instead of string concatenation.',
             });
           }

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -47,7 +47,7 @@ module.exports = {
           parent.parent.parent.type === 'CallExpression' &&
           contextIdentifiers.has(parent.parent.parent.callee.object) &&
           parent.parent.parent.callee.property.name === 'report' &&
-          utils.getReportInfo(parent.parent.parent.arguments).fix === node;
+          utils.getReportInfo(parent.parent.parent.arguments, context).fix === node;
 
         funcInfo = {
           upper: funcInfo,

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const { getStaticValue } = require('eslint-utils');
 const utils = require('../utils');
 
 // ------------------------------------------------------------------------------
@@ -35,9 +36,11 @@ module.exports = {
      * @returns {void}
      */
     function processMessageNode (message) {
+      const staticValue = getStaticValue(message, context.getScope());
       if (
         (message.type === 'Literal' && typeof message.value === 'string' && !pattern.test(message.value)) ||
-        (message.type === 'TemplateLiteral' && message.quasis.length === 1 && !pattern.test(message.quasis[0].value.cooked))
+        (message.type === 'TemplateLiteral' && message.quasis.length === 1 && !pattern.test(message.quasis[0].value.cooked)) ||
+        (staticValue && !pattern.test(staticValue.value))
       ) {
         context.report({
           node: message,
@@ -75,7 +78,7 @@ module.exports = {
           contextIdentifiers.has(node.callee.object) &&
           node.callee.property.type === 'Identifier' && node.callee.property.name === 'report'
         ) {
-          const reportInfo = utils.getReportInfo(node.arguments);
+          const reportInfo = utils.getReportInfo(node.arguments, context);
           const message = reportInfo && reportInfo.message;
 
           if (!message) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getStaticValue } = require('eslint-utils');
+
 /**
 * Determines whether a node is a 'normal' (i.e. non-async, non-generator) function expression.
 * @param {ASTNode} node The node in question
@@ -260,8 +262,9 @@ module.exports = {
   /**
   * Gets information on a report, given the arguments passed to context.report().
   * @param {ASTNode[]} reportArgs The arguments passed to context.report()
+  * @param {Context} context
   */
-  getReportInfo (reportArgs) {
+  getReportInfo (reportArgs, context) {
     // If there is exactly one argument, the API expects an object.
     // Otherwise, if the second argument is a string, the arguments are interpreted as
     // ['node', 'message', 'data', 'fix'].
@@ -287,15 +290,17 @@ module.exports = {
 
     let keys;
 
+    const secondArgStaticValue = getStaticValue(reportArgs[1], context.getScope());
     if (
-      (reportArgs[1].type === 'Literal' && typeof reportArgs[1].value === 'string') ||
+      (secondArgStaticValue && typeof secondArgStaticValue.value === 'string') ||
       reportArgs[1].type === 'TemplateLiteral'
     ) {
       keys = ['node', 'message', 'data', 'fix'];
     } else if (
       reportArgs[1].type === 'ObjectExpression' ||
       reportArgs[1].type === 'ArrayExpression' ||
-      (reportArgs[1].type === 'Literal' && typeof reportArgs[1].value !== 'string')
+      (reportArgs[1].type === 'Literal' && typeof reportArgs[1].value !== 'string') ||
+      (secondArgStaticValue && ['object', 'number'].includes(typeof secondArgStaticValue.value))
     ) {
       keys = ['node', 'loc', 'message', 'data', 'fix'];
     } else {

--- a/tests/lib/rules/prefer-placeholders.js
+++ b/tests/lib/rules/prefer-placeholders.js
@@ -60,6 +60,24 @@ ruleTester.run('prefer-placeholders', rule, {
         }
       };
     `,
+    // With message in variable.
+    `
+      const MESSAGE = 'foo is bad.';
+      module.exports = {
+        create(context) {
+          context.report(node, MESSAGE);
+        }
+      };
+    `,
+    // With message in variable but cannot statically determine its value.
+    `
+      const MESSAGE = getMessage();
+      module.exports = {
+        create(context) {
+          context.report(node, MESSAGE);
+        }
+      };
+    `,
   ],
 
   invalid: [
@@ -70,6 +88,21 @@ ruleTester.run('prefer-placeholders', rule, {
             context.report({
               node,
               message: \`\${foo} is bad.\`
+            });
+          }
+        };
+      `,
+      errors: [ERROR],
+    },
+    {
+      // With message in variable.
+      code: `
+        const MESSAGE = \`\${foo} is bad.\`;
+        module.exports = {
+          create(context) {
+            context.report({
+              node,
+              message: MESSAGE
             });
           }
         };

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -34,6 +34,30 @@ ruleTester.run('report-message-format', rule, {
       options: ['foo'],
     },
     {
+      // With message as variable.
+      code: `
+        const MESSAGE = 'foo';
+        module.exports = {
+          create(context) {
+            context.report(node, MESSAGE);
+          }
+        };
+      `,
+      options: ['foo'],
+    },
+    {
+      // With message as variable but cannot statically determine its type.
+      code: `
+        const MESSAGE = getMessage();
+        module.exports = {
+          create(context) {
+            context.report(node, MESSAGE);
+          }
+        };
+      `,
+      options: ['foo'],
+    },
+    {
       code: `
         module.exports = {
           create(context) {
@@ -135,6 +159,18 @@ ruleTester.run('report-message-format', rule, {
         module.exports = {
           create(context) {
             context.report(node, 'bar');
+          }
+        };
+      `,
+      options: ['foo'],
+    },
+    {
+      // With message as variable.
+      code: `
+        const MESSAGE = 'bar';
+        module.exports = {
+          create(context) {
+            context.report(node, MESSAGE);
           }
         };
       `,

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -352,7 +352,8 @@ describe('utils', () => {
           `context.report(${args.join(', ')})`,
           { ecmaVersion: 6, loc: false, range: false }
         ).body[0].expression.arguments;
-        const reportInfo = utils.getReportInfo(parsedArgs);
+        const context = { getScope () {} }; // mock object
+        const reportInfo = utils.getReportInfo(parsedArgs, context);
 
         assert.deepEqual(reportInfo, CASES.get(args)(parsedArgs));
       });


### PR DESCRIPTION
Several of our rules check the arguments of `context.report()`. This PR makes some improvements:

1. When inferring the arguments passed to `context.report()` in `utils.getReportInfo()`, take into account the static value of the second argument when available.
2. Update the rules using `utils.getReportInfo()` to also consider the static value or variable declaration of the message argument when necessary.

I noticed these issues because in a number of my plugins, we have stored rule error messages in variables like `const MESSAGE = 'do A instead of B';`, and this prevented many of the eslint-plugin-eslint-plugin rules from operating correctly.

Example of how this improvement enables the `no-deprecated-report-api` rule to correctly autofix this code (previously no autofix):

```js
const MESSAGE = 'do A instead of B';
module.exports = {
    create(context) {
		// Before autofix
    	context.report(theNode, MESSAGE);

		// After autofix
		context.report({node: theNode, message: MESSAGE});
	}
};
```