### PR TITLE
Add `markdownlint` for doc formatting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "line-length": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+LICENSE.md
+node_modules

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ An ESLint plugin for linting ESLint plugins
 
 You'll first need to install [ESLint](https://eslint.org):
 
-```
-$ npm i eslint --save-dev
+```sh
+npm i eslint --save-dev
 ```
 
 Next, install `eslint-plugin-eslint-plugin`:
 
-```
-$ npm install eslint-plugin-eslint-plugin --save-dev
+```sh
+npm install eslint-plugin-eslint-plugin --save-dev
 ```
 
 ## Usage
@@ -27,7 +27,6 @@ Add `eslint-plugin` to the plugins section of your `.eslintrc` configuration fil
     ]
 }
 ```
-
 
 Then configure the rules you want to use under the rules section.
 

--- a/docs/rules/no-deprecated-report-api.md
+++ b/docs/rules/no-deprecated-report-api.md
@@ -37,7 +37,6 @@ module.exports = {
 };
 ```
 
-
 ## Further Reading
 
 * [Deprecated rule API](http://eslint.org/docs/developer-guide/working-with-rules-deprecated)

--- a/docs/rules/no-missing-placeholders.md
+++ b/docs/rules/no-missing-placeholders.md
@@ -14,7 +14,6 @@ context.report({
 
 However, if no `data` argument is provided, or no matching replacement key exists in the `data` argument, the raw curly brackets will end up in the report message. This is usually a mistake.
 
-
 ## Rule Details
 
 This rule aims to disallow missing placeholders in rule report messages.
@@ -66,7 +65,6 @@ module.exports = {
 };
 
 ```
-
 
 ## When Not To Use It
 

--- a/docs/rules/require-meta-docs-description.md
+++ b/docs/rules/require-meta-docs-description.md
@@ -3,6 +3,7 @@
 Defining a clear and consistent description for each rule helps developers understand what they're used for.
 
 In particular, each rule description should begin with an allowed prefix:
+
 * `enforce`
 * `require`
 * `disallow`
@@ -40,7 +41,7 @@ module.exports = {
 
 This rule takes an optional object containing:
 
-- `String` — `pattern` — A regular expression that the description must match. Use `'.+'` to allow anything. Defaults to `^(enforce|require|disallow)`.
+* `String` — `pattern` — A regular expression that the description must match. Use `'.+'` to allow anything. Defaults to `^(enforce|require|disallow)`.
 
 ## Further Reading
 

--- a/docs/rules/require-meta-docs-url.md
+++ b/docs/rules/require-meta-docs-url.md
@@ -142,7 +142,7 @@ Then `npm version <type>` command will update every rule to the new version's UR
 
 > npm runs `preversion` script on the current version, runs `version` script on the new version, and commits and makes a tag.
 >
-> Further reading: https://docs.npmjs.com/cli/version
+> Further reading: <https://docs.npmjs.com/cli/version>
 
 ## When Not To Use It
 

--- a/docs/rules/test-case-shorthand-strings.md
+++ b/docs/rules/test-case-shorthand-strings.md
@@ -169,8 +169,7 @@ ruleTester.run('example-rule', rule, {
 });
 ```
 
-<!-- markdownlint-disable-next-line no-duplicate-header -->
-#### `never`
+#### `consistent-as-needed`
 
 Examples of **incorrect** code for this rule with the `consistent-as-needed` option:
 

--- a/docs/rules/test-case-shorthand-strings.md
+++ b/docs/rules/test-case-shorthand-strings.md
@@ -169,6 +169,7 @@ ruleTester.run('example-rule', rule, {
 });
 ```
 
+<!-- markdownlint-disable-next-line no-duplicate-header -->
 #### `never`
 
 Examples of **incorrect** code for this rule with the `consistent-as-needed` option:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint . --ignore-pattern \"!.*\"",
+    "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
+    "lint:docs": "markdownlint **/*.md",
+    "lint:js": "eslint . --ignore-pattern \"!.*\"",
     "generate-readme-table": "node build/generate-readme-table.js",
     "generate-release": "node-release-script",
     "test": "mocha tests --recursive"
@@ -42,7 +44,9 @@
     "espree": "^7.3.0",
     "estraverse": "^5.0.0",
     "lodash": "^4.17.2",
-    "mocha": "^7.1.1"
+    "markdownlint-cli": "^0.27.1",
+    "mocha": "^7.1.1",
+    "npm-run-all": "^4.1.5"
   },
   "peerDependencies": {
     "eslint": "^7.0.0"


### PR DESCRIPTION
Add popular tool for enforcing best markdown practices: https://github.com/igorshubovych/markdownlint-cli

Autofixed most violations.