### PR TITLE
Add eslint-plugin-markdown for JavaScript code samples in documentation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,10 @@
 
 module.exports = {
   root: true,
-  plugins: ['node', 'self'],
+  plugins: ['node'],
   extends: [
     'not-an-aardvark/node',
     'plugin:node/recommended',
-    'plugin:self/all',
     'plugin:unicorn/recommended',
   ],
   parserOptions: {
@@ -24,10 +23,6 @@ module.exports = {
     ],
     'require-jsdoc': 'error',
 
-    'self/meta-property-ordering': 'off',
-    'self/require-meta-docs-url': 'off',
-    'self/report-message-format': ['error', '^[^a-z].*.$'],
-
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/no-array-callback-reference': 'off',
     'unicorn/no-array-for-each': 'off',
@@ -38,8 +33,36 @@ module.exports = {
   },
   overrides: [
     {
+      // Apply eslint-plugin rules to our own rules/tests (but not docs).
+      files: ['lib/**/*.js', 'tests/**/*.js'],
+      plugins: ['self'],
+      extends: ['plugin:self/all'],
+      rules: {
+        'self/meta-property-ordering': 'off',
+        'self/report-message-format': ['error', '^[^a-z].*.$'],
+        'self/require-meta-docs-url': 'off',
+      },
+    },
+    {
       files: ['tests/**/*.js'],
       env: { mocha: true },
+    },
+    {
+      files: ['**/*.md'],
+      processor: 'markdown/markdown',
+    },
+    {
+      // Markdown JS code samples in documentation:
+      files: ['**/*.md/*.js'],
+      plugins: ['markdown'],
+      noInlineConfig: true,
+      rules: {
+        'no-undef': 'off',
+        'no-unused-vars': 'off',
+        strict: 'off',
+
+        'unicorn/filename-case': 'off',
+      },
     },
   ],
 };

--- a/docs/rules/consistent-output.md
+++ b/docs/rules/consistent-output.md
@@ -21,15 +21,14 @@ new RuleTester().run('example-rule', rule, {
     {
       code: 'foo',
       output: 'bar',
-      errors: ['baz']
+      errors: ['baz'],
     },
     {
       code: 'bar',
-      errors: ['baz']
-    }
-  ]
+      errors: ['baz'],
+    },
+  ],
 });
-
 ```
 
 Examples of **correct** code for this rule:
@@ -43,21 +42,20 @@ new RuleTester().run('example-rule', rule, {
     {
       code: 'foo',
       output: 'bar',
-      errors: ['baz']
+      errors: ['baz'],
     },
     {
       code: 'bar',
       output: 'qux',
-      errors: ['baz']
+      errors: ['baz'],
     },
     {
       code: 'foo',
       output: null, // asserts that there is no autofix
-      errors: ['baz']
-    }
-  ]
+      errors: ['baz'],
+    },
+  ],
 });
-
 ```
 
 ## Options

--- a/docs/rules/fixer-return.md
+++ b/docs/rules/fixer-return.md
@@ -10,14 +10,15 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/fixer-return: error */
+
 module.exports = {
-    create: function(context) {
-        context.report( {
-            fix: function(fixer) {
-                fixer.foo();
-            }
-        });
-    }
+  create (context) {
+    context.report({
+      fix (fixer) {
+        fixer.foo();
+      },
+    });
+  },
 };
 ```
 
@@ -25,14 +26,15 @@ Examples of **correct** code for this rule:
 
 ```js
 /* eslint eslint-plugin/fixer-return: error */
+
 module.exports = {
-    create: function(context) {
-        context.report( {
-            fix: function(fixer) {
-                return fixer.foo();
-            }
-        });
-    }
+  create (context) {
+    context.report({
+      fix (fixer) {
+        return fixer.foo();
+      },
+    });
+  },
 };
 ```
 

--- a/docs/rules/meta-property-ordering.md
+++ b/docs/rules/meta-property-ordering.md
@@ -23,23 +23,23 @@ Examples of **incorrect** code for this rule:
 // invalid; wrong order.
 module.exports = {
   meta: {
-    docs: "",
-    type: "problem",
-    fixable: "code",
+    docs: '',
+    type: 'problem',
+    fixable: 'code',
   },
-  create() {},
-}
+  create () {},
+};
 
 // invalid; extra properties must be placed afterwards.
 module.exports = {
   meta: {
-    type: "problem",
-    fooooooooo: "foo",
-    docs: "",
-    fixable: "code",
+    type: 'problem',
+    fooooooooo: 'foo',
+    docs: '',
+    fixable: 'code',
   },
-  create() {},
-}
+  create () {},
+};
 ```
 
 Examples of **correct** code for this rule:
@@ -52,13 +52,13 @@ Examples of **correct** code for this rule:
 // valid;
 module.exports = {
   meta: {
-    type: "bar",
-    docs: "foo",
-    messages: ["zoo"],
-    fooooooooo: "foo",
+    type: 'bar',
+    docs: 'foo',
+    messages: ['zoo'],
+    fooooooooo: 'foo',
   },
-  create() {},
-}
+  create () {},
+};
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-deprecated-context-methods.md
+++ b/docs/rules/no-deprecated-context-methods.md
@@ -35,29 +35,29 @@ Examples of **incorrect** code for this rule:
 
 ```js
 module.exports = {
-  create(context) {
+  create (context) {
     return {
-      Program(node) {
+      Program (node) {
         const firstToken = context.getFirstToken(node);
-      }
-    }
-  }
-}
+      },
+    };
+  },
+};
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
 module.exports = {
-  create(context) {
+  create (context) {
     const sourceCode = context.getSourceCode();
 
     return {
-      Program(node) {
+      Program (node) {
         const firstToken = sourceCode.getFirstToken(node);
-      }
-    }
-  }
+      },
+    };
+  },
 };
 ```
 

--- a/docs/rules/no-deprecated-report-api.md
+++ b/docs/rules/no-deprecated-report-api.md
@@ -12,13 +12,9 @@ The following patterns are considered warnings:
 
 ```js
 module.exports = {
-  create(context) {
-
+  create (context) {
     context.report(node, 'This node is bad.');
-
-    context.report(node, loc, 'This node is bad.');
-
-  }
+  },
 };
 
 ```
@@ -27,13 +23,11 @@ The following patterns are not warnings:
 
 ```js
 module.exports = {
-  create(context) {
-
+  create (context) {
     context.report({ node, message: 'This node is bad.' });
 
     context.report({ node, loc, message: 'This node is bad.' });
-
-  }
+  },
 };
 ```
 

--- a/docs/rules/no-identical-tests.md
+++ b/docs/rules/no-identical-tests.md
@@ -12,13 +12,12 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/no-identical-tests: error */
 
 new RuleTester().run('foo', bar, {
-valid: [
+  valid: [
     { code: 'foo' },
-    { code: 'foo' }
-],
-invalid: []
+    { code: 'foo' },
+  ],
+  invalid: [],
 });
-
 ```
 
 Examples of **correct** code for this rule:
@@ -27,13 +26,12 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/no-identical-tests: error */
 
 new RuleTester().run('foo', bar, {
-valid: [
+  valid: [
     { code: 'foo' },
-    { code: 'bar' }
-],
-invalid: []
+    { code: 'bar' },
+  ],
+  invalid: [],
 });
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-missing-placeholders.md
+++ b/docs/rules/no-missing-placeholders.md
@@ -6,7 +6,7 @@ Report messages in rules can have placeholders surrounded by curly brackets.
 context.report({
   node,
   message: '{{disallowedNode}} nodes are not allowed.',
-  data: { disallowedNode: node.type }
+  data: { disallowedNode: node.type },
 });
 
 // Resulting message: e.g. 'IfStatement nodes are not allowed.'
@@ -21,49 +21,47 @@ This rule aims to disallow missing placeholders in rule report messages.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint eslint-plugin/no-missing-placeholders: error*/
+/* eslint eslint-plugin/no-missing-placeholders: error*/
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: '{{something}} is wrong.'
+      message: '{{something}} is wrong.',
     });
 
     context.report({
       node,
       message: '{{something}} is wrong.',
-      data: { somethingElse: 'foo' }
+      data: { somethingElse: 'foo' },
     });
 
     context.report(node, '{{something}} is wrong.', { somethingElse: 'foo' });
-  }
+  },
 };
-
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint eslint-plugin/no-missing-placeholders: error*/
+/* eslint eslint-plugin/no-missing-placeholders: error*/
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: 'something is wrong.'
+      message: 'something is wrong.',
     });
 
     context.report({
       node,
       message: '{{something}} is wrong.',
-      data: { something: 'foo' }
+      data: { something: 'foo' },
     });
 
     context.report(node, '{{something}} is wrong.', { something: 'foo' });
-  }
+  },
 };
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-unused-placeholders.md
+++ b/docs/rules/no-unused-placeholders.md
@@ -9,42 +9,41 @@ Reports when a context.report call contains a data property that does not have a
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint eslint-plugin/no-unused-placeholders: error*/
+/* eslint eslint-plugin/no-unused-placeholders: error*/
 
 module.exports = {
-  create(context) {
-
+  create (context) {
     context.report({
       node,
       message: 'something is wrong.',
-      data: { something: 'foo' }
+      data: { something: 'foo' },
     });
 
     context.report(node, 'something is wrong.', { something: 'foo' });
-  }
+  },
 };
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint eslint-plugin/no-unused-placeholders: error*/
+/* eslint eslint-plugin/no-unused-placeholders: error*/
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: 'something is wrong.'
+      message: 'something is wrong.',
     });
 
     context.report({
       node,
       message: '{{something}} is wrong.',
-      data: { something: 'foo' }
+      data: { something: 'foo' },
     });
 
     context.report(node, '{{something}} is wrong.', { something: 'foo' });
-  }
+  },
 };
 ```
 

--- a/docs/rules/no-useless-token-range.md
+++ b/docs/rules/no-useless-token-range.md
@@ -12,12 +12,12 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/no-useless-token-range: error */
 
 module.exports = {
-  create(context) {
+  create (context) {
     const sourceCode = context.getSourceCode();
 
     const rangeStart = sourceCode.getFirstToken(node).range[0];
     const rangeEnd = sourceCode.getLastToken(node).range[1];
-  }
+  },
 };
 ```
 
@@ -27,12 +27,12 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/no-useless-token-range: error */
 
 module.exports = {
-  create(context) {
+  create (context) {
     const sourceCode = context.getSourceCode();
 
     const rangeStart = node.range[0];
     const rangeEnd = node.range[1];
-  }
+  },
 };
 ```
 

--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -12,15 +12,21 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/prefer-object-rule: error */
 
 module.exports = function (context) {
-  return { Program() { context.report() } };
+  return { Program () {
+    context.report();
+  } };
 };
 
-module.exports = function create(context) {
-  return { Program() { context.report() } };
+module.exports = function create (context) {
+  return { Program () {
+    context.report();
+  } };
 };
 
-module.exports = (context) => {
-  return { Program() { context.report() } };
+module.exports = context => {
+  return { Program () {
+    context.report();
+  } };
 };
 ```
 
@@ -30,20 +36,26 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/prefer-object-rule: error */
 
 module.exports = {
-  create(context) {
-    return { Program() { context.report() } };
+  create (context) {
+    return { Program () {
+      context.report();
+    } };
   },
 };
 
 module.exports = {
-  create(context) {
-    return { Program() { context.report() } };
+  create (context) {
+    return { Program () {
+      context.report();
+    } };
   },
 };
 
 module.exports = {
-  create: (context) => {
-    return { Program() { context.report() } };
+  create: context => {
+    return { Program () {
+      context.report();
+    } };
   },
 };
 ```

--- a/docs/rules/prefer-output-null.md
+++ b/docs/rules/prefer-output-null.md
@@ -14,10 +14,10 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/prefer-output-null: error */
 
 new RuleTester().run('foo', bar, {
-    valid: [],
-    invalid: [
-      { code: 'foo', output: 'foo', errors: [{ message: 'bar' }] },
-    ]
+  valid: [],
+  invalid: [
+    { code: 'foo', output: 'foo', errors: [{ message: 'bar' }] },
+  ],
 });
 ```
 
@@ -27,9 +27,9 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/prefer-output-null: error */
 
 new RuleTester().run('foo', bar, {
-    valid: [],
-    invalid: [
-      { code: 'foo', output: null, errors: [{ message: 'bar' }] },
-    ]
+  valid: [],
+  invalid: [
+    { code: 'foo', output: null, errors: [{ message: 'bar' }] },
+  ],
 });
 ```

--- a/docs/rules/prefer-placeholders.md
+++ b/docs/rules/prefer-placeholders.md
@@ -6,7 +6,7 @@ Report messages in rules can have placeholders surrounded by curly brackets.
 context.report({
   node,
   message: '{{disallowedNode}} nodes are not allowed.',
-  data: { disallowedNode: node.type }
+  data: { disallowedNode: node.type },
 });
 ```
 
@@ -25,17 +25,17 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/prefer-placeholders: error */
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: `The node ${node.name} is not allowed to be used.`
+      message: `The node ${node.name} is not allowed to be used.`,
     });
 
     context.report({
       node,
-      message: 'The node ' + node.name + ' is not allowed to be used.'
+      message: 'The node ' + node.name + ' is not allowed to be used.',
     });
-  }
+  },
 };
 ```
 
@@ -45,13 +45,13 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/prefer-placeholders: error */
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'The node {{name}} is not allowed to be used.',
-      data: { name: node.name }
+      data: { name: node.name },
     });
-  }
+  },
 };
 ```
 

--- a/docs/rules/prefer-replace-text.md
+++ b/docs/rules/prefer-replace-text.md
@@ -8,15 +8,16 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/prefer-replace-text: error */
+
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
-      fix(fixer) {
-        // error, can be written: return fixer.replaceText([node, '']);
+      fix (fixer) {
+        // error, can be written: return fixer.replaceText([node, '']);
         return fixer.replaceTextRange([node.range[0], node.range[1]], '');
-      }
+      },
     });
-  }
+  },
 };
 ```
 
@@ -24,26 +25,27 @@ Examples of **correct** code for this rule:
 
 ```js
 /* eslint eslint-plugin/prefer-replace-text: error */
+
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
-      fix(fixer) {
+      fix (fixer) {
         return fixer.replaceText(node, '');
-      }
+      },
     });
-  }
+  },
 };
 
 module.exports = {
-  create(context) {
+  create (context) {
     context.report({
-      fix(fixer) {
+      fix (fixer) {
         // start = ...
         // end = ...
         return fixer.replaceTextRange([start, end], '');
-      }
+      },
     });
-  }
+  },
 };
 ```
 

--- a/docs/rules/report-message-format.md
+++ b/docs/rules/report-message-format.md
@@ -32,34 +32,27 @@ The following patterns are considered warnings:
 
 module.exports = {
   meta: {},
-  create(context) {
-
+  create (context) {
     context.report(node, 'this message does not match the regular expression.');
 
     context.report(node, 'Neither does this one');
 
-    context.report(node, 'This will get reported, regardless of the value of the {{placeholder}}', { placeholder: foo })
-
-  }
+    context.report(node, 'This will get reported, regardless of the value of the {{placeholder}}', { placeholder: foo });
+  },
 };
-
 ```
 
 The following patterns are not warnings:
 
 ```js
-
 module.exports = {
   meta: {},
-  create(context) {
-
+  create (context) {
     context.report(node, 'This message matches the regular expression.');
 
     context.report(node, 'So does this one.');
-
-  }
+  },
 };
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/require-meta-docs-description.md
+++ b/docs/rules/require-meta-docs-description.md
@@ -16,14 +16,15 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-docs-description: error */
+
 module.exports = {
-    meta: {},
-    create: function(context) { /* ... */}
+  meta: {},
+  create (context) {/* ... */},
 };
 
 module.exports = {
-    meta: { description: 'this rule does ...' }, // missing allowed prefix
-    create: function(context) { /* ... */}
+  meta: { description: 'this rule does ...' }, // missing allowed prefix
+  create (context) {/* ... */},
 };
 ```
 
@@ -31,9 +32,10 @@ Examples of **correct** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-docs-description: error */
+
 module.exports = {
-    meta: { description: 'disallow unused variables' },
-    create: function(context) { /* ... */}
+  meta: { description: 'disallow unused variables' },
+  create (context) {/* ... */},
 };
 ```
 

--- a/docs/rules/require-meta-docs-url.md
+++ b/docs/rules/require-meta-docs-url.md
@@ -28,8 +28,7 @@ The following patterns are considered warnings:
 
 module.exports = {
   meta: {},
-  create(context) {
-  }
+  create (context) {},
 };
 
 ```
@@ -41,11 +40,10 @@ module.exports = {
 module.exports = {
   meta: {
     docs: {
-      url: undefined
-    }
+      url: undefined,
+    },
   },
-  create(context) {
-  }
+  create (context) {},
 };
 
 ```
@@ -57,11 +55,10 @@ module.exports = {
 module.exports = {
   meta: {
     docs: {
-      url: "wrong URL"
-    }
+      url: 'wrong URL',
+    },
   },
-  create(context) {
-  }
+  create (context) {},
 };
 
 ```
@@ -75,11 +72,10 @@ The following patterns are not warnings:
 module.exports = {
   meta: {
     docs: {
-      url: "a URL"
-    }
+      url: 'a URL',
+    },
   },
-  create(context) {
-  }
+  create (context) {},
 };
 
 ```
@@ -91,11 +87,10 @@ module.exports = {
 module.exports = {
   meta: {
     docs: {
-      url: "path/to/rule-name.md"
-    }
+      url: 'path/to/rule-name.md',
+    },
   },
-  create(context) {
-  }
+  create (context) {},
 };
 
 ```
@@ -108,19 +103,16 @@ For example:
 **.eslintrc.js**:
 
 ```js
-"use strict"
-
-const version = require("./package.json").version
+// const version = require("./package.json").version;
 
 module.exports = {
-  plugins: ["eslint-plugin"],
-  // ... leaving out ...
+  plugins: ['eslint-plugin'],
   rules: {
-    "eslint-plugin/require-meta-docs-url": ["error", {
+    'eslint-plugin/require-meta-docs-url': ['error', {
       pattern: `path/to/v${version}/docs/rules/{{name}}.md`,
     }],
-  }
-}
+  },
+};
 ```
 
 **package.json**:
@@ -133,8 +125,7 @@ module.exports = {
     "test": "... leaving out ...",
     "preversion": "npm test",
     "version": "eslint . --fix && git add ."
-  },
-  // ... leaving out ...
+  }
 }
 ```
 

--- a/docs/rules/require-meta-fixable.md
+++ b/docs/rules/require-meta-fixable.md
@@ -9,94 +9,84 @@ This rule aims to require ESLint rules to have a `meta.fixable` property if nece
 The following patterns are considered warnings:
 
 ```js
-
 /* eslint eslint-plugin/require-meta-fixable: "error" */
 
 module.exports = {
   meta: {},
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'foo',
-      fix(fixer) {
+      fix (fixer) {
         return fixer.remove(node);
-      }
+      },
     });
-  }
+  },
 };
-
 ```
 
 ```js
-
 /* eslint eslint-plugin/require-meta-fixable: "error" */
 
 module.exports = {
   meta: { fixable: 'not a valid meta.fixable value' },
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'foo',
-      fix(fixer) {
+      fix (fixer) {
         return fixer.remove(node);
-      }
+      },
     });
-  }
+  },
 };
-
 ```
 
 ```js
-
 /* eslint eslint-plugin/require-meta-fixable: "error" */
 
-module.exports = function create(context) {
+module.exports = { create (context) {
   context.report({
     node,
     message: 'foo',
-    fix(fixer) {
+    fix (fixer) {
       return fixer.remove(node);
-    }
+    },
   });
-};
-
+} };
 ```
 
 The following patterns are not warnings:
 
 ```js
-
 /* eslint eslint-plugin/require-meta-fixable: "error" */
 
 module.exports = {
   meta: { fixable: 'code' },
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'foo',
-      fix(fixer) {
+      fix (fixer) {
         return fixer.remove(node);
-      }
+      },
     });
-  }
+  },
 };
-
 ```
 
 ```js
-
 /* eslint eslint-plugin/require-meta-fixable: "error" */
 
 module.exports = {
   meta: {},
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: 'foo'
+      message: 'foo',
     });
-  }
+  },
 };
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/require-meta-has-suggestions.md
+++ b/docs/rules/require-meta-has-suggestions.md
@@ -11,81 +11,73 @@ This rule aims to require ESLint rules to have a `meta.hasSuggestions` property 
 The following patterns are considered warnings:
 
 ```js
-
 /* eslint eslint-plugin/require-meta-has-suggestions: "error" */
 
 module.exports = {
   meta: {}, // Missing `meta.hasSuggestions`.
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'foo',
       suggest: [
         {
-            desc: 'Insert space at the beginning',
-            fix: fixer => fixer.insertTextBefore(node, " ")
-        }
-      ]
+          desc: 'Insert space at the beginning',
+          fix: fixer => fixer.insertTextBefore(node, ' '),
+        },
+      ],
     });
-  }
+  },
 };
-
 ```
 
 ```js
-
 /* eslint eslint-plugin/require-meta-has-suggestions: "error" */
 
 module.exports = {
   meta: { hasSuggestions: true }, // Has `meta.hasSuggestions` enabled but never provides suggestions.
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: 'foo'
+      message: 'foo',
     });
-  }
+  },
 };
-
 ```
 
 The following patterns are not warnings:
 
 ```js
-
 /* eslint eslint-plugin/require-meta-has-suggestions: "error" */
 
 module.exports = {
   meta: { hasSuggestions: true },
-  create(context) {
+  create (context) {
     context.report({
       node,
       message: 'foo',
       suggest: [
         {
-            desc: 'Insert space at the beginning',
-            fix: fixer => fixer.insertTextBefore(node, " ")
-        }
-      ]
+          desc: 'Insert space at the beginning',
+          fix: fixer => fixer.insertTextBefore(node, ' '),
+        },
+      ],
     });
-  }
+  },
 };
-
 ```
 
 ```js
-
 /* eslint eslint-plugin/require-meta-has-suggestions: "error" */
 
 module.exports = {
   meta: {},
-  create(context) {
+  create (context) {
     context.report({
       node,
-      message: 'foo'
+      message: 'foo',
     });
-  }
+  },
 };
-
 ```
 
 ## Further Reading

--- a/docs/rules/require-meta-schema.md
+++ b/docs/rules/require-meta-schema.md
@@ -10,14 +10,15 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-schema: error */
+
 module.exports = {
-    meta: {},
-    create: function(context) { /* ... */}
+  meta: {},
+  create (context) {/* ... */},
 };
 
 module.exports = {
-    meta: { schema: null },
-    create: function(context) { /* ... */}
+  meta: { schema: null },
+  create (context) {/* ... */},
 };
 ```
 
@@ -25,26 +26,27 @@ Examples of **correct** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-schema: error */
+
 module.exports = {
-    meta: { schema: [] }, // ensures no options are passed to the rule
-    create: function(context) { /* ... */}
+  meta: { schema: [] }, // ensures no options are passed to the rule
+  create (context) {/* ... */},
 };
 
 module.exports = {
-    meta: {
-        schema: [
-            {
-                type: 'object',
-                properties: {
-                    exceptRange: {
-                        type: 'boolean'
-                    }
-                },
-                additionalProperties: false
-            }
-        ]
-    },
-    create: function(context) { /* ... */}
+  meta: {
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          exceptRange: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create (context) {/* ... */},
 };
 ```
 

--- a/docs/rules/require-meta-type.md
+++ b/docs/rules/require-meta-type.md
@@ -16,18 +16,19 @@ Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-type: error */
+
 module.exports = {
-    meta: {},
-    create: function(context) {
-        // ...
-    }
+  meta: {},
+  create (context) {
+    // ...
+  },
 };
 
 module.exports = {
-    meta: {type: 'invalid'},
-    create: function(context) {
-        // ...
-    }
+  meta: { type: 'invalid' },
+  create (context) {
+    // ...
+  },
 };
 ```
 
@@ -35,11 +36,12 @@ Examples of **correct** code for this rule:
 
 ```js
 /* eslint eslint-plugin/require-meta-type: error */
+
 module.exports = {
-    meta: {type: 'problem'},
-    create: function(context) {
-        // ...
-    }
+  meta: { type: 'problem' },
+  create (context) {
+    // ...
+  },
 };
 ```
 

--- a/docs/rules/test-case-property-ordering.md
+++ b/docs/rules/test-case-property-ordering.md
@@ -21,20 +21,20 @@ Examples of **incorrect** code for this rule:
 ] */
 
 // invalid; wrong order
-{
-  code: "foo",
-  options: ["baz"],
-  output: "bar",
-}
+const testCase1 = {
+  code: 'foo',
+  options: ['baz'],
+  output: 'bar',
+};
 
 
 // invalid; extra properties should need to be placed afterwards.
-{
-  code: "foo",
+const testCase2 = {
+  code: 'foo',
   env: { es6: true },
-  output: "bar",
-  options: ["baz"],
-}
+  output: 'bar',
+  options: ['baz'],
+};
 ```
 
 Examples of **correct** code for this rule:
@@ -45,11 +45,11 @@ Examples of **correct** code for this rule:
 ] */
 
 // valid;
-{
-  code: "foo",
-  output: "bar",
-  options: ["baz"],
-}
+const testCase1 = {
+  code: 'foo',
+  output: 'bar',
+  options: ['baz'],
+};
 
 ```
 

--- a/docs/rules/test-case-shorthand-strings.md
+++ b/docs/rules/test-case-shorthand-strings.md
@@ -11,12 +11,12 @@ ruleTester.run('example-rule', rule, {
 
     // longform object
     {
-      code: 'anotherValidTestCase;'
-    }
+      code: 'anotherValidTestCase;',
+    },
   ],
   invalid: [
     // ...
-  ]
+  ],
 });
 ```
 
@@ -45,13 +45,13 @@ Examples of **incorrect** code for this rule with the default `as-needed` option
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase;'
-    }
+      code: 'anotherValidTestCase;',
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -66,10 +66,10 @@ ruleTester.run('example-rule', rule, {
     'anotherValidTestCase;',
     {
       code: 'testCaseWithOption;',
-      options: ["foo"]
-    }
+      options: ['foo'],
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -83,9 +83,9 @@ Examples of **incorrect** code for this rule with the `never` option:
 ruleTester.run('example-rule', rule, {
   valid: [
     'validTestCase;',
-    'anotherValidTestCase;'
+    'anotherValidTestCase;',
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -97,13 +97,13 @@ Examples of **correct** code for this rule with the `never` option:
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase;'
-    }
+      code: 'anotherValidTestCase;',
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -120,10 +120,10 @@ ruleTester.run('example-rule', rule, {
     'anotherValidTestCase;',
     {
       code: 'testCaseWithOption',
-      options: ["foo"]
-    }
+      options: ['foo'],
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -135,37 +135,37 @@ Examples of **correct** code for this rule with the `consistent` option:
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase'
+      code: 'anotherValidTestCase',
     },
     {
       code: 'testCaseWithOption',
-      options: ["foo"]
-    }
+      options: ['foo'],
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 
 ruleTester.run('example-rule', rule, {
   valid: [
     'validTestCase;',
-    'anotherValidTestCase'
+    'anotherValidTestCase',
   ],
-  invalid: []
+  invalid: [],
 });
 
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase'
-    }
+      code: 'anotherValidTestCase',
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -180,10 +180,10 @@ ruleTester.run('example-rule', rule, {
   valid: [
     'validTestCase;',
     {
-      code: 'anotherValidTestCase'
-    }
+      code: 'anotherValidTestCase',
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 
 ruleTester.run('example-rule', rule, {
@@ -192,22 +192,22 @@ ruleTester.run('example-rule', rule, {
     'anotherValidTestCase;',
     {
       code: 'testCaseWithOption;',
-      options: ['foo']
-    }
+      options: ['foo'],
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase;'
-    }
+      code: 'anotherValidTestCase;',
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 
@@ -219,25 +219,25 @@ Examples of **correct** code for this rule with the `consistent-as-needed` optio
 ruleTester.run('example-rule', rule, {
   valid: [
     'validTestCase;',
-    'anotherValidTestCase;'
+    'anotherValidTestCase;',
   ],
-  invalid: []
+  invalid: [],
 });
 
 ruleTester.run('example-rule', rule, {
   valid: [
     {
-      code: 'validTestCase;'
+      code: 'validTestCase;',
     },
     {
-      code: 'anotherValidTestCase;'
+      code: 'anotherValidTestCase;',
     },
     {
       code: 'testCaseWithOption;',
-      options: ['foo']
-    }
+      options: ['foo'],
+    },
   ],
-  invalid: []
+  invalid: [],
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dirty-chai": "^2.0.1",
     "eslint": "^7.9.0",
     "eslint-config-not-an-aardvark": "^2.1.0",
+    "eslint-plugin-markdown": "^2.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-self": "^1.2.1",
     "eslint-plugin-unicorn": "^31.0.0",


### PR DESCRIPTION
This applies our JavaScript linting to the JavaScript code samples in the markdown documentation files. Goal is to generally improve the quality, reliability, and consistency of our documentation.

* Autofixes styling/formatting/whitespace
* Fixes and prevents syntax errors