### PR TITLE
Enable `meta-property-ordering` rule internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
       plugins: ['self'],
       extends: ['plugin:self/all'],
       rules: {
-        'self/meta-property-ordering': 'off',
         'self/report-message-format': ['error', '^[^a-z].*.$'],
         'self/require-meta-docs-url': 'off',
       },

--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'enforce consistent use of output assertions in rule tests',
       category: 'Tests',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: null, // or "code" or "whitespace"
     schema: [
       {

--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -17,12 +17,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'require fixer function to always return a value.',
       category: 'Possible Errors',
       recommended: true,
     },
-    type: 'problem',
     fixable: null,
     schema: [],
   },

--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -12,12 +12,12 @@ const { getKeyName, getRuleInfo } = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'enforce the order of meta properties',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [{
       type: 'array',

--- a/lib/rules/no-deprecated-context-methods.js
+++ b/lib/rules/no-deprecated-context-methods.js
@@ -36,12 +36,12 @@ const DEPRECATED_PASSTHROUGHS = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow usage of deprecated methods on rule context objects',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [],
   },

--- a/lib/rules/no-deprecated-report-api.js
+++ b/lib/rules/no-deprecated-report-api.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow use of the deprecated context.report() API',
       category: 'Rules',
       recommended: true,
     },
-    type: 'suggestion',
     fixable: 'code', // or "code" or "whitespace"
     schema: [],
   },

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'disallow identical tests',
       category: 'Tests',
       recommended: true,
     },
-    type: 'problem',
     fixable: 'code',
     schema: [],
   },

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -14,12 +14,12 @@ const { getStaticValue } = require('eslint-utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'disallow missing placeholders in rule report messages',
       category: 'Rules',
       recommended: true,
     },
-    type: 'problem',
     fixable: null,
     schema: [],
   },

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -14,12 +14,12 @@ const { getStaticValue } = require('eslint-utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'disallow unused placeholders in rule report messages',
       category: 'Rules',
       recommended: true,
     },
-    type: 'problem',
     fixable: null,
     schema: [],
   },

--- a/lib/rules/no-useless-token-range.js
+++ b/lib/rules/no-useless-token-range.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow unnecessary calls to sourceCode.getFirstToken and sourceCode.getLastToken',
       category: 'Rules',
       recommended: true,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [],
   },

--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -12,17 +12,17 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow rule exports where the export is a function.',
       category: 'Rules',
       recommended: false,
     },
+    fixable: 'code',
+    schema: [],
     messages: {
       preferObject: 'Rules should be declared using the object style.',
     },
-    type: 'suggestion',
-    fixable: 'code',
-    schema: [],
   },
 
   create (context) {

--- a/lib/rules/prefer-output-null.js
+++ b/lib/rules/prefer-output-null.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow invalid RuleTester test cases with the output the same as the code.',
       category: 'Tests',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [],
   },

--- a/lib/rules/prefer-placeholders.js
+++ b/lib/rules/prefer-placeholders.js
@@ -14,12 +14,12 @@ const { findVariable } = require('eslint-utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'disallow template literals as report messages',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: null,
     schema: [],
   },

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'require using replaceText instead of replaceTextRange.',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: null,
     schema: [],
   },

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -14,12 +14,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'enforce a consistent format for rule report messages',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: null,
     schema: [
       { type: 'string' },

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -11,12 +11,12 @@ const DEFAULT_PATTERN = new RegExp('^(enforce|require|disallow)');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'require rules to implement a meta.docs.description property with the correct format',
       category: 'Rules',
       recommended: false, // TODO: enable it in a major release.
     },
-    type: 'suggestion',
     fixable: null,
     schema: [
       {

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -17,12 +17,12 @@ const util = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'require rules to implement a meta.docs.url property',
       category: 'Rules',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [{
       type: 'object',

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'require rules to implement a meta.fixable property',
       category: 'Rules',
       recommended: true,
     },
-    type: 'problem',
     schema: [],
   },
 

--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -9,17 +9,17 @@ const { getStaticValue } = require('eslint-utils');
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'require suggestable rules to implement a `meta.hasSuggestions` property',
       category: 'Rules',
       recommended: false,
     },
-    type: 'problem',
+    schema: [],
     messages: {
       shouldBeSuggestable: 'Suggestable rules should specify a `meta.hasSuggestions` property with value `true`.',
       shouldNotBeSuggestable: 'Non-suggestable rules should not specify a `meta.hasSuggestions` property with value `true`.',
     },
-    schema: [],
   },
 
   create (context) {

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -9,12 +9,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'require rules to implement a meta.schema property',
       category: 'Rules',
       recommended: false, // TODO: enable it in a major release.
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [
       {

--- a/lib/rules/require-meta-type.js
+++ b/lib/rules/require-meta-type.js
@@ -14,12 +14,12 @@ const VALID_TYPES = new Set(['problem', 'suggestion', 'layout']);
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'require rules to implement a meta.type property',
       category: 'Rules',
       recommended: false, // TODO: enable it in a major release.
     },
-    type: 'problem',
     fixable: null,
     schema: [],
     messages: {

--- a/lib/rules/test-case-property-ordering.js
+++ b/lib/rules/test-case-property-ordering.js
@@ -13,12 +13,12 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'require the properties of a test case to be placed in a consistent order',
       category: 'Tests',
       recommended: false,
     },
-    type: 'suggestion',
     fixable: 'code',
     schema: [{
       type: 'array',

--- a/lib/rules/test-case-shorthand-strings.js
+++ b/lib/rules/test-case-shorthand-strings.js
@@ -13,14 +13,14 @@ const utils = require('../utils');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'enforce consistent usage of shorthand strings for test cases with no options',
       category: 'Tests',
       recommended: false,
     },
-    type: 'suggestion',
-    schema: [{ enum: ['as-needed', 'never', 'consistent', 'consistent-as-needed'] }],
     fixable: 'code',
+    schema: [{ enum: ['as-needed', 'never', 'consistent', 'consistent-as-needed'] }],
   },
 
   create (context) {


### PR DESCRIPTION
This was autofixed.

We should use our own rules internally as an additional means of testing/dogfooding them in real-world usage.