### PR TITLE
Add sort-package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,41 +2,43 @@
   "name": "eslint-plugin-eslint-plugin",
   "version": "3.1.0",
   "description": "An ESLint plugin for linting ESLint plugins",
-  "author": "Teddy Katz",
-  "main": "lib/index.js",
-  "license": "MIT",
-  "scripts": {
-    "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint **/*.md",
-    "lint:js": "eslint . --ignore-pattern \"!.*\"",
-    "generate-readme-table": "node build/generate-readme-table.js",
-    "generate-release": "node-release-script",
-    "test": "nyc --all --check-coverage --include lib mocha tests --recursive"
-  },
-  "files": [
-    "lib/"
-  ],
   "keywords": [
     "eslint",
     "eslintplugin",
     "eslint-plugin"
   ],
+  "homepage": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin#readme",
+  "bugs": {
+    "url": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin.git"
   },
-  "bugs": {
-    "url": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues"
-  },
-  "homepage": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin#readme",
-  "dependencies": {
-    "eslint-utils": "^2.1.0"
+  "license": "MIT",
+  "author": "Teddy Katz",
+  "main": "lib/index.js",
+  "files": [
+    "lib/"
+  ],
+  "scripts": {
+    "generate-readme-table": "node build/generate-readme-table.js",
+    "generate-release": "node-release-script",
+    "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
+    "lint:docs": "markdownlint **/*.md",
+    "lint:js": "eslint . --ignore-pattern \"!.*\"",
+    "lint:package-json": "sort-package-json --check",
+    "lint:package-json:fix": "sort-package-json",
+    "test": "nyc --all --check-coverage --include lib mocha tests --recursive"
   },
   "nyc": {
     "branches": 96,
     "functions": 98,
     "lines": 98,
     "statements": 98
+  },
+  "dependencies": {
+    "eslint-utils": "^2.1.0"
   },
   "devDependencies": {
     "@not-an-aardvark/node-release-script": "^0.1.0",
@@ -55,7 +57,8 @@
     "markdownlint-cli": "^0.27.1",
     "mocha": "^7.1.1",
     "npm-run-all": "^4.1.5",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "sort-package-json": "^1.50.0"
   },
   "peerDependencies": {
     "eslint": "^7.0.0"


### PR DESCRIPTION
https://www.npmjs.com/package/sort-package-json

Adds this dev dependency with two new NPM scripts to run/fix the package.json field sorting checks:

```
"lint:package-json": "sort-package-json --check",
"lint:package-json:fix": "sort-package-json",
```

If you don't find enough value to this addition, feel free to close.