### PR TITLE
Enforce minimum test code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+.idea
+.nyc_output
+.vscode
 node_modules/
 npm-debug.log
-.vscode
-.idea
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:js": "eslint . --ignore-pattern \"!.*\"",
     "generate-readme-table": "node build/generate-readme-table.js",
     "generate-release": "node-release-script",
-    "test": "mocha tests --recursive"
+    "test": "nyc --all --check-coverage --include lib mocha tests --recursive"
   },
   "files": [
     "lib/"
@@ -32,6 +32,12 @@
   "dependencies": {
     "eslint-utils": "^2.1.0"
   },
+  "nyc": {
+    "branches": 96,
+    "functions": 98,
+    "lines": 98,
+    "statements": 98
+  },
   "devDependencies": {
     "@not-an-aardvark/node-release-script": "^0.1.0",
     "chai": "^4.1.0",
@@ -48,7 +54,8 @@
     "lodash": "^4.17.2",
     "markdownlint-cli": "^0.27.1",
     "mocha": "^7.1.1",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "nyc": "^15.1.0"
   },
   "peerDependencies": {
     "eslint": "^7.0.0"


### PR DESCRIPTION
The current test coverage data looks like the below table, and I set the minimum code coverage percentages based on this.

As a follow-up, we can add tests to cover the uncovered lines, and possibly raise the test coverage percentages further.

This addition should help prevent developers from submitting PRs which are missing test coverage, saving everyone time during PR review.

https://github.com/istanbuljs/nyc

```
-----------------------------------|---------|----------|---------|---------|-------------------
File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------------|---------|----------|---------|---------|-------------------
All files                          |   98.36 |    96.43 |   98.94 |   98.65 |                   
 lib                               |   98.66 |    97.26 |     100 |   98.62 |                   
  index.js                         |     100 |      100 |     100 |     100 |                   
  utils.js                         |    98.4 |    97.14 |     100 |   98.35 | 57,285            
 lib/rules                         |   98.26 |    96.19 |   98.56 |   98.65 |                   
  consistent-output.js             |     100 |      100 |     100 |     100 |                   
  fixer-return.js                  |   94.74 |       85 |     100 |   94.74 | 109               
  meta-property-ordering.js        |     100 |      100 |     100 |     100 |                   
  no-deprecated-context-methods.js |     100 |      100 |     100 |     100 |                   
  no-deprecated-report-api.js      |     100 |      100 |     100 |     100 |                   
  no-identical-tests.js            |   93.94 |       75 |     100 |   93.75 | 42,54             
  no-missing-placeholders.js       |     100 |      100 |     100 |     100 |                   
  no-unused-placeholders.js        |     100 |      100 |     100 |     100 |                   
  no-useless-token-range.js        |     100 |      100 |     100 |     100 |                   
  prefer-object-rule.js            |   94.44 |    83.33 |     100 |   94.44 | 57                
  prefer-output-null.js            |   94.12 |       60 |     100 |   93.75 | 48                
  prefer-placeholders.js           |     100 |      100 |     100 |     100 |                   
  prefer-replace-text.js           |     100 |      100 |     100 |     100 |                   
  report-message-format.js         |     100 |    97.06 |     100 |     100 | 48                
  require-meta-docs-description.js |    96.3 |    96.88 |     100 |    96.3 | 46                
  require-meta-docs-url.js         |     100 |      100 |     100 |     100 |                   
  require-meta-fixable.js          |     100 |    92.86 |     100 |     100 | 69                
  require-meta-has-suggestions.js  |     100 |      100 |     100 |     100 |                   
  require-meta-schema.js           |     100 |      100 |     100 |     100 |                   
  require-meta-type.js             |     100 |      100 |     100 |     100 |                   
  test-case-property-ordering.js   |   95.83 |    83.33 |   88.89 |     100 | 52,62             
  test-case-shorthand-strings.js   |      96 |      100 |   92.86 |     100 |                   
-----------------------------------|---------|----------|---------|---------|-------------------
```