### PR TITLE
Update `fixer-return` rule to handle arrow function expressions

### DIFF
--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -47,19 +47,17 @@ module.exports = {
      * If not, report the function as a violation.
      *
      * @param {ASTNode} node - A node to check.
+     * @param {Location} loc - Optional location to report violation on.
      * @returns {void}
      */
-    function checkLastSegment (node) {
+    function ensureFunctionReturnedFix (node, loc = (node.id || node).loc.start) {
       if (
-        funcInfo.shouldCheck &&
-        (
-          (node.generator && !funcInfo.hasYieldWithFixer) || // Generator function never yielded a fix
-          (!node.generator && !funcInfo.hasReturnWithFixer) // Non-generator function never returned a fix
-        )
+        (node.generator && !funcInfo.hasYieldWithFixer) || // Generator function never yielded a fix
+        (!node.generator && !funcInfo.hasReturnWithFixer) // Non-generator function never returned a fix
       ) {
         context.report({
           node,
-          loc: (node.id || node).loc.start,
+          loc,
           messageId: 'missingFix',
         });
       }
@@ -103,7 +101,7 @@ module.exports = {
         const parent = node.parent;
 
         // Whether we are inside the fixer function we care about.
-        const shouldCheck = node.type === 'FunctionExpression' &&
+        const shouldCheck = ['FunctionExpression', 'ArrowFunctionExpression'].includes(node.type) &&
           parent.parent.type === 'ObjectExpression' &&
           parent.parent.parent.type === 'CallExpression' &&
           contextIdentifiers.has(parent.parent.parent.callee.object) &&
@@ -140,7 +138,30 @@ module.exports = {
       },
 
       // Ensure the current fixer function returned or yielded a fix.
-      'FunctionExpression:exit': checkLastSegment,
+      'FunctionExpression:exit' (node) {
+        if (funcInfo.shouldCheck) {
+          ensureFunctionReturnedFix(node);
+        }
+      },
+
+      // Ensure the current (arrow) fixer function returned a fix.
+      'ArrowFunctionExpression:exit' (node) {
+        if (funcInfo.shouldCheck) {
+          const loc = context.getSourceCode().getTokenBefore(node.body).loc; // Show violation on arrow (=>).
+          if (node.expression) {
+            // When the return is implied (no curly braces around the body), we have to check the single body node directly.
+            if (!isFix(node.body)) {
+              context.report({
+                node,
+                loc,
+                messageId: 'missingFix',
+              });
+            }
+          } else {
+            ensureFunctionReturnedFix(node, loc);
+          }
+        }
+      },
     };
   },
 };


### PR DESCRIPTION
Also improves test coverage including updating the tests to ensure each violation is reported at the correct location (since the location differs depending on the function type).

The lack of coverage for arrow functions was a bug / omission in the rule.