### PR TITLE
Chore: Update `eslint-utils` to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin#readme",
   "dependencies": {
-    "eslint-utils": "^2.1.0"
+    "eslint-utils": "^3.0.0"
   },
   "nyc": {
     "branches": 96,


### PR DESCRIPTION
This is technically a breaking change because we still support Node 13 but eslint-utils v3 does not.

https://github.com/mysticatea/eslint-utils/releases/tag/v3.0.0

Planned for v4 release (https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/120).