### PR TITLE
Remove unnecessary ignore pattern from internal js linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint **/*.md",
-    "lint:js": "eslint . --ignore-pattern \"!.*\"",
+    "lint:js": "eslint .",
     "generate-readme-table": "node build/generate-readme-table.js",
     "generate-release": "node-release-script",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive"


### PR DESCRIPTION
This ignore pattern is no longer necessary (ESLint lints .eslintrc.js as of [ESLint 7](https://eslint.org/blog/2020/05/eslint-v7.0.0-released)), and it was causing ESLint to lint some files in node_modules for me locally.