### PR TITLE
Chore: Fully adopt `messageId` in `require-meta-docs-description` rule

### DIFF
--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -30,9 +30,10 @@ module.exports = {
       },
     ],
     messages: {
+      extraWhitespace: '`meta.docs.description` must not have leading nor trailing whitespace.',
+      mismatch: '`meta.docs.description` must match the regexp {{pattern}}.',
       missing: '`meta.docs.description` is required.',
       wrongType: '`meta.docs.description` must be a non-empty string.',
-      extraWhitespace: '`meta.docs.description` must not have leading nor trailing whitespace.',
     },
   },
 
@@ -77,7 +78,7 @@ module.exports = {
         } else if (!pattern.test(staticValue.value)) {
           context.report({
             node: descriptionNode.value,
-            message: '`meta.docs.description` must match the regexp {{pattern}}.',
+            messageId: 'mismatch',
             data: { pattern },
           });
         }


### PR DESCRIPTION
One usage was missing it.