### PR TITLE
Fix: Ensure `require-meta-*` rules test `null` / `undefined` property values

### DIFF
--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -68,7 +68,7 @@ module.exports = {
         }
 
         let { value } = schemaNode;
-        if (value.type === 'Identifier') {
+        if (value.type === 'Identifier' && value.name !== 'undefined') {
           const variable = findVariable(
             scopeManager.acquire(value) || scopeManager.globalScope,
             value

--- a/tests/lib/rules/require-meta-docs-description.js
+++ b/tests/lib/rules/require-meta-docs-description.js
@@ -136,6 +136,26 @@ ruleTester.run('require-meta-docs-description', rule, {
     },
     {
       code: `
+        module.exports = {
+          meta: { docs: { description: null } },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ messageId: 'wrongType', type: 'Literal' }],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { docs: { description: undefined } },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ messageId: 'wrongType', type: 'Identifier' }],
+    },
+    {
+      code: `
         const DESCRIPTION = true;
         module.exports = {
           meta: { docs: { description: DESCRIPTION } },

--- a/tests/lib/rules/require-meta-has-suggestions.js
+++ b/tests/lib/rules/require-meta-has-suggestions.js
@@ -74,6 +74,24 @@ ruleTester.run('require-meta-has-suggestions', rule, {
       }
     };
     `,
+    // No suggestions reported, hasSuggestions property set to `null`.
+    `
+    module.exports = {
+      meta: { hasSuggestions: null },
+      create(context) {
+        context.report({node, message});
+      }
+    };
+    `,
+    // No suggestions reported, hasSuggestions property set to `undefined`.
+    `
+    module.exports = {
+      meta: { hasSuggestions: undefined },
+      create(context) {
+        context.report({node, message});
+      }
+    };
+    `,
     // No suggestions reported, hasSuggestions property set to false (as variable).
     `
     const hasSuggestions = false;

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -131,6 +131,16 @@ schema: [] },
     },
     {
       code: `
+        module.exports = {
+          meta: { schema: undefined },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ messageId: 'wrongType', type: 'Identifier' }],
+    },
+    {
+      code: `
         const schema = null;
         module.exports = {
           meta: { schema },


### PR DESCRIPTION
We need to ensure that the rules correctly handle `null` / `undefined` as the value of the meta properties since these values are commonly used as placeholder values.

Fixes one bug and adds test coverage.
