### PR TITLE
New: Add `catchNoFixerButFixableProperty` option (default false) to catch non-fixable rules that enable the fixable property in `require-meta-fixable` rule

### DIFF
--- a/docs/rules/require-meta-fixable.md
+++ b/docs/rules/require-meta-fixable.md
@@ -44,6 +44,17 @@ module.exports = {
 };
 ```
 
+```js
+/* eslint eslint-plugin/require-meta-fixable: ["error", { catchNoFixerButFixableProperty: true }] */
+
+module.exports = {
+  meta: { fixable: 'code' }, // property enabled but no fixer detected
+  create (context) {
+    context.report({ node, message: 'foo' });
+  },
+};
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -76,6 +87,12 @@ module.exports = {
   },
 };
 ```
+
+## Options
+
+This rule takes an optional object containing:
+
+* `boolean` — `catchNoFixerButFixableProperty` — default `false` - Whether the rule should attempt to detect rules that do not have a fixer but enable the `meta.fixable` property. This option is off by default because it increases the chance of false positives since fixers can't always be detected when helper functions are used.
 
 ## Further Reading
 

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -40,7 +40,7 @@ module.exports = {
   },
 
   create (context) {
-    const catchFixerButFixableValue = context.options[0] && context.options[0].catchNoFixerButFixableProperty;
+    const catchNoFixerButFixableProperty = context.options[0] && context.options[0].catchNoFixerButFixableProperty;
 
     const sourceCode = context.getSourceCode();
     const ruleInfo = utils.getRuleInfo(sourceCode);
@@ -96,7 +96,7 @@ module.exports = {
           if (usesFixFunctions && !['code', 'whitespace'].includes(staticValue.value)) {
             // Rule is fixable but `fixable` property does not have a fixable value.
             context.report({ node: metaFixableProp.value, messageId: 'missing' });
-          } else if (catchFixerButFixableValue && !usesFixFunctions && ['code', 'whitespace'].includes(staticValue.value)) {
+          } else if (catchNoFixerButFixableProperty && !usesFixFunctions && ['code', 'whitespace'].includes(staticValue.value)) {
             // Rule is NOT fixable but `fixable` property has a fixable value.
             context.report({ node: metaFixableProp.value, messageId: 'noFixerButFixableValue' });
           }

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -20,14 +20,28 @@ module.exports = {
       category: 'Rules',
       recommended: true,
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          catchNoFixerButFixableProperty: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       invalid: '`meta.fixable` must be either `code`, `whitespace`, or `null`.',
       missing: '`meta.fixable` must be either `code` or `whitespace` for fixable rules.',
+      noFixerButFixableValue: '`meta.fixable` is enabled but no fixer detected.',
     },
   },
 
   create (context) {
+    const catchFixerButFixableValue = context.options[0] && context.options[0].catchNoFixerButFixableProperty;
+
     const sourceCode = context.getSourceCode();
     const ruleInfo = utils.getRuleInfo(sourceCode);
     let contextIdentifiers;
@@ -82,6 +96,9 @@ module.exports = {
           if (usesFixFunctions && !['code', 'whitespace'].includes(staticValue.value)) {
             // Rule is fixable but `fixable` property does not have a fixable value.
             context.report({ node: metaFixableProp.value, messageId: 'missing' });
+          } else if (catchFixerButFixableValue && !usesFixFunctions && ['code', 'whitespace'].includes(staticValue.value)) {
+            // Rule is NOT fixable but `fixable` property has a fixable value.
+            context.report({ node: metaFixableProp.value, messageId: 'noFixerButFixableValue' });
           }
         } else if (!metaFixableProp && usesFixFunctions) {
           // Rule is fixable but is missing the `fixable` property.

--- a/tests/lib/rules/require-meta-fixable.js
+++ b/tests/lib/rules/require-meta-fixable.js
@@ -157,6 +157,20 @@ ruleTester.run('require-meta-fixable', rule, {
       `,
       options: [{ catchNoFixerButFixableProperty: false }],
     },
+    // catchNoFixerButFixableProperty = true
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: 'code' },
+          create(context) {
+            foo
+              ? context.report({ node, message })
+              : context.report({ node, message, fix });
+          }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: true }],
+    },
   ],
 
   invalid: [
@@ -253,6 +267,16 @@ ruleTester.run('require-meta-fixable', rule, {
       `,
       options: [{ catchNoFixerButFixableProperty: true }],
       errors: [{ messageId: 'noFixerButFixableValue', type: 'Literal' }],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: null },
+          create(context) { context.report({node, message, fix}); }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: true }],
+      errors: [{ messageId: 'missing', type: 'Literal' }],
     },
   ],
 });

--- a/tests/lib/rules/require-meta-fixable.js
+++ b/tests/lib/rules/require-meta-fixable.js
@@ -78,14 +78,6 @@ ruleTester.run('require-meta-fixable', rule, {
     `,
     `
       module.exports = {
-        meta: { fixable: 'code' },
-        create(context) {
-          context.report({node, message});
-        }
-      };
-    `,
-    `
-      module.exports = {
         meta: { fixable: null },
         create(context) {
           context.report({node, message});
@@ -131,6 +123,39 @@ ruleTester.run('require-meta-fixable', rule, {
       parserOptions: {
         ecmaVersion: 9,
       },
+    },
+
+    // catchNoFixerButFixableProperty = false (implicitly)
+    `
+      module.exports = {
+        meta: { fixable: 'code' },
+        create(context) { context.report({node, message}); }
+      };
+    `,
+    `
+      module.exports = {
+        meta: { fixable: 'whitespace' },
+        create(context) { context.report({node, message}); }
+      };
+    `,
+    // catchNoFixerButFixableProperty = false (explicitly)
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: 'code' },
+          create(context) { context.report({node, message}); }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: false }],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: 'whitespace' },
+          create(context) { context.report({node, message}); }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: false }],
     },
   ],
 
@@ -206,6 +231,28 @@ ruleTester.run('require-meta-fixable', rule, {
         };
       `,
       errors: [{ messageId: 'missing', type: 'Identifier' }],
+    },
+
+    // catchNoFixerButFixableProperty = true
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: 'code' },
+          create(context) { context.report({node, message}); }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: true }],
+      errors: [{ messageId: 'noFixerButFixableValue', type: 'Literal' }],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { fixable: 'whitespace' },
+          create(context) { context.report({node, message}); }
+        };
+      `,
+      options: [{ catchNoFixerButFixableProperty: true }],
+      errors: [{ messageId: 'noFixerButFixableValue', type: 'Literal' }],
     },
   ],
 });


### PR DESCRIPTION
Added behind an option due to risk of false positives.

Open to better names for the option.