### PR TITLE
Fix: Fix false positive with empty array variable in `require-meta-has-suggestions` rule

### DIFF
--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -47,7 +47,11 @@ module.exports = {
           const suggestProp = node.arguments[0].properties.find(prop => utils.getKeyName(prop) === 'suggest');
           if (suggestProp) {
             const staticValue = getStaticValue(suggestProp.value, context.getScope());
-            if (!staticValue || (Array.isArray(staticValue.value) && staticValue.value.length > 0)) {
+            if (
+              !staticValue ||
+                (Array.isArray(staticValue.value) && staticValue.value.length > 0) ||
+                (Array.isArray(staticValue.value) && staticValue.value.length === 0 && suggestProp.value.type === 'Identifier') // Array variable can have suggestions pushed to it.
+            ) {
               // These are all considered reporting suggestions:
               //   suggest: [{...}]
               //   suggest: getSuggestions()

--- a/tests/lib/rules/require-meta-has-suggestions.js
+++ b/tests/lib/rules/require-meta-has-suggestions.js
@@ -55,13 +55,14 @@ ruleTester.run('require-meta-has-suggestions', rule, {
       }
     };
     `,
-    // No suggestions reported (empty suggest array in variable), no suggestion property.
+    // Suggestions reported (pushing to an array variable), suggestion property.
     `
-    const SUGGESTIONS = [];
+    const suggest = [];
+    suggest.push({});
     module.exports = {
-      meta: {},
+      meta: { hasSuggestions: true },
       create(context) {
-        context.report({node, message, suggest: SUGGESTIONS});
+        context.report({node, message, suggest});
       }
     };
     `,
@@ -234,6 +235,26 @@ ruleTester.run('require-meta-has-suggestions', rule, {
         };
       `,
       errors: [{ messageId: 'shouldBeSuggestable', type: 'ObjectExpression', line: 4, column: 17, endLine: 4, endColumn: 19 }],
+    },
+    {
+      // Reports suggestions (in variable, with pushing), no hasSuggestions property, violation should be on `meta` object.
+      code: `
+        const suggest = [];
+        suggest.push({});
+        module.exports = {
+          meta: {},
+          create(context) { context.report({node, message, suggest}); }
+        };
+      `,
+      output: `
+        const suggest = [];
+        suggest.push({});
+        module.exports = {
+          meta: { hasSuggestions: true },
+          create(context) { context.report({node, message, suggest}); }
+        };
+      `,
+      errors: [{ messageId: 'shouldBeSuggestable', type: 'ObjectExpression', line: 5, column: 17, endLine: 5, endColumn: 19 }],
     },
     {
       // Reports suggestions, hasSuggestions property set to false, violation should be on `false`


### PR DESCRIPTION
If the suggestions array is initialized as an empty array variable, we need to assume that someone may have pushed suggestion objects to it, so we should consider that a usage of suggestions.

Previously, this rule incorrectly assumed that using `const suggest = []; ... context.report({suggest,...});` meant the rule was not using suggestions.

Real world example here: https://github.com/eslint/eslint/blob/master/lib/rules/no-nonoctal-decimal-escape.js#L91