### PR TITLE
Fix: False negative in `prefer-message-ids` rule

### DIFF
--- a/lib/rules/prefer-message-ids.js
+++ b/lib/rules/prefer-message-ids.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const utils = require('../utils');
+const { getStaticValue } = require('eslint-utils');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,11 +18,15 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {
+      messagesMissing: '`meta.messages` must contain at least one violation message.',
       foundMessage: 'Use `messageId` instead of `message`.',
     },
   },
 
   create (context) {
+    const sourceCode = context.getSourceCode();
+    const info = utils.getRuleInfo(sourceCode);
+
     let contextIdentifiers;
 
     // ----------------------------------------------------------------------
@@ -31,6 +36,30 @@ module.exports = {
     return {
       Program (ast) {
         contextIdentifiers = utils.getContextIdentifiers(context, ast);
+
+        if (info === null || info.meta === null) {
+          return;
+        }
+
+        const metaNode = info.meta;
+        const messagesNode =
+          metaNode &&
+          metaNode.properties &&
+          metaNode.properties.find(p => p.type === 'Property' && utils.getKeyName(p) === 'messages');
+
+        if (!messagesNode) {
+          context.report({ node: metaNode, messageId: 'messagesMissing' });
+          return;
+        }
+
+        const staticValue = getStaticValue(messagesNode.value, context.getScope());
+        if (!staticValue) {
+          return;
+        }
+
+        if (typeof staticValue.value === 'object' && staticValue.value.constructor === Object && Object.keys(staticValue.value).length === 0) {
+          context.report({ node: messagesNode.value, messageId: 'messagesMissing' });
+        }
       },
       CallExpression (node) {
         if (

--- a/tests/lib/rules/prefer-message-ids.js
+++ b/tests/lib/rules/prefer-message-ids.js
@@ -58,6 +58,26 @@ ruleTester.run('prefer-message-ids', rule, {
         ]
       });
     `,
+
+    // `meta.messages` has a message
+    `
+      module.exports = {
+        meta: { messages: { someMessageId: 'some message' } },
+        create(context) {
+          context.report({ node, messageId: 'someMessageId' });
+        }
+      };
+    `,
+    // `meta.messages` has a message (in variable)
+    `
+      const messages = { someMessageId: 'some message' };
+      module.exports = {
+        meta: { messages },
+        create(context) {
+          context.report({ node, messageId: 'someMessageId' });
+        }
+      };
+    `,
   ],
 
   invalid: [
@@ -99,6 +119,61 @@ ruleTester.run('prefer-message-ids', rule, {
         };
       `,
       errors: [{ messageId: 'foundMessage', type: 'Property' }],
+    },
+
+    {
+      // `meta.messages` missing
+      code: `
+        module.exports = {
+          meta: { description: 'foo' },
+          create(context) { }
+        };
+      `,
+      errors: [{ messageId: 'messagesMissing', type: 'ObjectExpression' }],
+    },
+    {
+      // `meta.messages` empty
+      code: `
+        module.exports = {
+          meta: {
+            description: 'foo',
+            messages: {},
+          },
+          create(context) { }
+        };
+      `,
+      errors: [{ messageId: 'messagesMissing', type: 'ObjectExpression' }],
+    },
+    {
+      // `meta.messages` empty (in variable)
+      code: `
+        const messages = {};
+        module.exports = {
+          meta: {
+            description: 'foo',
+            messages,
+          },
+          create(context) { }
+        };
+      `,
+      errors: [{ messageId: 'messagesMissing', type: 'Identifier' }],
+    },
+    {
+      // `meta.messages` missing and using `message`
+      code: `
+        module.exports = {
+          meta: {
+            description: 'foo',
+          },
+          create(context) {
+            context.report({ node, message: 'foo' });
+          }
+        };
+      `,
+      errors: [
+        { messageId: 'messagesMissing', type: 'ObjectExpression' },
+        { messageId: 'foundMessage', type: 'Property' },
+      ],
     },
   ],
 });


### PR DESCRIPTION
In some rules, `context` is passed to functions that eventually call `context.report()`, like [`no-duplicate-imports`](https://github.com/eslint/eslint/blob/8be8a36010145dfcd31cbdd4f781a91989e3b1bd/lib/rules/no-duplicate-imports.js#L176) or [`padding-lines-between-statements`](https://github.com/eslint/eslint/blob/8be8a36010145dfcd31cbdd4f781a91989e3b1bd/lib/rules/padding-line-between-statements.js#L244), and that will prevent this existing rule from flagging such instances of `context.report({ message: ... });`.

So in addition to flagging that, we should also flag when rules are simply missing `meta.messages`, as all rules using message IDs should have at least one violation message defined in that object.

This will unblock this PR: https://github.com/eslint/eslint/pull/14841#issuecomment-888645170

CC: @mdjermanovic