### PR TITLE
Breaking: Support ESM rules

### DIFF
--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -46,7 +46,7 @@ module.exports = {
             // note - we intentionally don't worry about formatting here, as otherwise we have
             //        to indent the function correctly
 
-            if (ruleInfo.create.type === 'FunctionExpression') {
+            if (ruleInfo.create.type === 'FunctionExpression' || ruleInfo.create.type === 'FunctionDeclaration') {
               const openParenToken = sourceCode.getFirstToken(
                 ruleInfo.create,
                 token => token.type === 'Punctuator' && token.value === '('

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,8 +83,93 @@ function isRuleTesterConstruction (node) {
   );
 }
 
-module.exports = {
+const INTERESTING_RULE_KEYS = new Set(['create', 'meta']);
 
+/**
+ * Helper for `getRuleInfo`. Handles ESM rules.
+ */
+function getRuleExportsESM (ast) {
+  return ast.body
+    .filter(statement => statement.type === 'ExportDefaultDeclaration')
+    .map(statement => statement.declaration)
+    // eslint-disable-next-line unicorn/prefer-object-from-entries
+    .reduce((currentExports, node) => {
+      if (node.type === 'ObjectExpression') {
+        // eslint-disable-next-line unicorn/prefer-object-from-entries
+        return node.properties.reduce((parsedProps, prop) => {
+          const keyValue = module.exports.getKeyName(prop);
+          if (INTERESTING_RULE_KEYS.has(keyValue)) {
+            parsedProps[keyValue] = prop.value;
+          }
+          return parsedProps;
+        }, {});
+      } else if (isNormalFunctionExpression(node)) {
+        return { create: node, meta: null, isNewStyle: false };
+      }
+      return currentExports;
+    }, {});
+}
+
+/**
+ * Helper for `getRuleInfo`. Handles CJS rules.
+ */
+function getRuleExportsCJS (ast) {
+  let exportsVarOverridden = false;
+  let exportsIsFunction = false;
+  return ast.body
+    .filter(statement => statement.type === 'ExpressionStatement')
+    .map(statement => statement.expression)
+    .filter(expression => expression.type === 'AssignmentExpression')
+    .filter(expression => expression.left.type === 'MemberExpression')
+    // eslint-disable-next-line unicorn/prefer-object-from-entries
+    .reduce((currentExports, node) => {
+      if (
+        node.left.object.type === 'Identifier' && node.left.object.name === 'module' &&
+        node.left.property.type === 'Identifier' && node.left.property.name === 'exports'
+      ) {
+        exportsVarOverridden = true;
+        if (isNormalFunctionExpression(node.right)) {
+          // Check `module.exports = function () {}`
+
+          exportsIsFunction = true;
+          return { create: node.right, meta: null, isNewStyle: false };
+        } else if (node.right.type === 'ObjectExpression') {
+          // Check `module.exports = { create: function () {}, meta: {} }`
+
+          // eslint-disable-next-line unicorn/prefer-object-from-entries
+          return node.right.properties.reduce((parsedProps, prop) => {
+            const keyValue = module.exports.getKeyName(prop);
+            if (INTERESTING_RULE_KEYS.has(keyValue)) {
+              parsedProps[keyValue] = prop.value;
+            }
+            return parsedProps;
+          }, {});
+        }
+        return {};
+      } else if (
+        !exportsIsFunction &&
+        node.left.object.type === 'MemberExpression' &&
+        node.left.object.object.type === 'Identifier' && node.left.object.object.name === 'module' &&
+        node.left.object.property.type === 'Identifier' && node.left.object.property.name === 'exports' &&
+        node.left.property.type === 'Identifier' && INTERESTING_RULE_KEYS.has(node.left.property.name)
+      ) {
+        // Check `module.exports.create = () => {}`
+
+        currentExports[node.left.property.name] = node.right;
+      } else if (
+        !exportsVarOverridden &&
+        node.left.object.type === 'Identifier' && node.left.object.name === 'exports' &&
+        node.left.property.type === 'Identifier' && INTERESTING_RULE_KEYS.has(node.left.property.name)
+      ) {
+        // Check `exports.create = () => {}`
+
+        currentExports[node.left.property.name] = node.right;
+      }
+      return currentExports;
+    }, {});
+}
+
+module.exports = {
   /**
   * Performs static analysis on an AST to try to determine the final value of `module.exports`.
   * @param {{ast: ASTNode, scopeManager?: ScopeManager}} sourceCode The object contains `Program` AST node, and optional `scopeManager`
@@ -94,63 +179,7 @@ module.exports = {
   from the file, the return value will be `null`.
   */
   getRuleInfo ({ ast, scopeManager }) {
-    const INTERESTING_KEYS = new Set(['create', 'meta']);
-    let exportsVarOverridden = false;
-    let exportsIsFunction = false;
-
-    const exportNodes = ast.body
-      .filter(statement => statement.type === 'ExpressionStatement')
-      .map(statement => statement.expression)
-      .filter(expression => expression.type === 'AssignmentExpression')
-      .filter(expression => expression.left.type === 'MemberExpression')
-      // eslint-disable-next-line unicorn/prefer-object-from-entries
-      .reduce((currentExports, node) => {
-        if (
-          node.left.object.type === 'Identifier' && node.left.object.name === 'module' &&
-          node.left.property.type === 'Identifier' && node.left.property.name === 'exports'
-        ) {
-          exportsVarOverridden = true;
-
-          if (isNormalFunctionExpression(node.right)) {
-            // Check `module.exports = function () {}`
-
-            exportsIsFunction = true;
-            return { create: node.right, meta: null };
-          } else if (node.right.type === 'ObjectExpression') {
-            // Check `module.exports = { create: function () {}, meta: {} }`
-
-            exportsIsFunction = false;
-            // eslint-disable-next-line unicorn/prefer-object-from-entries
-            return node.right.properties.reduce((parsedProps, prop) => {
-              const keyValue = module.exports.getKeyName(prop);
-              if (INTERESTING_KEYS.has(keyValue)) {
-                parsedProps[keyValue] = prop.value;
-              }
-              return parsedProps;
-            }, {});
-          }
-          return {};
-        } else if (
-          !exportsIsFunction &&
-          node.left.object.type === 'MemberExpression' &&
-          node.left.object.object.type === 'Identifier' && node.left.object.object.name === 'module' &&
-          node.left.object.property.type === 'Identifier' && node.left.object.property.name === 'exports' &&
-          node.left.property.type === 'Identifier' && INTERESTING_KEYS.has(node.left.property.name)
-        ) {
-          // Check `module.exports.create = () => {}`
-
-          currentExports[node.left.property.name] = node.right;
-        } else if (
-          !exportsVarOverridden &&
-          node.left.object.type === 'Identifier' && node.left.object.name === 'exports' &&
-          node.left.property.type === 'Identifier' && INTERESTING_KEYS.has(node.left.property.name)
-        ) {
-          // Check `exports.create = () => {}`
-
-          currentExports[node.left.property.name] = node.right;
-        }
-        return currentExports;
-      }, {});
+    const exportNodes = ast.sourceType === 'module' ? getRuleExportsESM(ast) : getRuleExportsCJS(ast);
 
     const createExists = Object.prototype.hasOwnProperty.call(exportNodes, 'create');
     if (!createExists) {
@@ -164,7 +193,7 @@ module.exports = {
       return null;
     }
 
-    return Object.assign({ isNewStyle: !exportsIsFunction, meta: null }, exportNodes);
+    return Object.assign({ isNewStyle: true, meta: null }, exportNodes);
   },
 
   /**

--- a/tests/lib/rules/meta-property-ordering.js
+++ b/tests/lib/rules/meta-property-ordering.js
@@ -24,6 +24,16 @@ ruleTester.run('test-case-property-ordering', rule, {
       create() {},
     };`,
 
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {type, docs, fixable, schema, messages},
+          create() {},
+        };`,
+      parserOptions: { sourceType: 'module' },
+    },
+
     `
     module.exports = {
       meta: {docs, schema, messages},
@@ -83,6 +93,30 @@ ruleTester.run('test-case-property-ordering', rule, {
           },
           create() {},
         };`,
+      errors: [{ messageId: 'inconsistentOrder', data: { order: ['type', 'docs', 'fixable'].join(', ') } }],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {
+            docs,
+            fixable,
+            type: 'problem',
+          },
+          create() {},
+        };`,
+
+      output: `
+        export default {
+          meta: {
+            type: 'problem',
+            docs,
+            fixable,
+          },
+          create() {},
+        };`,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'inconsistentOrder', data: { order: ['type', 'docs', 'fixable'].join(', ') } }],
     },
     {

--- a/tests/lib/rules/prefer-message-ids.js
+++ b/tests/lib/rules/prefer-message-ids.js
@@ -29,6 +29,17 @@ ruleTester.run('prefer-message-ids', rule, {
         }
       };
     `,
+    {
+      // ESM
+      code: `
+        export default {
+          create(context) {
+            context.report({ node, messageId: 'foo' });
+          }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     `
       module.exports = {
         create(context) {
@@ -89,6 +100,18 @@ ruleTester.run('prefer-message-ids', rule, {
           }
         };
       `,
+      errors: [{ messageId: 'foundMessage', type: 'Property' }],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          create(context) {
+            context.report({ node, message: 'foo' });
+          }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'foundMessage', type: 'Property' }],
     },
     {

--- a/tests/lib/rules/prefer-object-rule.js
+++ b/tests/lib/rules/prefer-object-rule.js
@@ -11,8 +11,6 @@
 const rule = require('../../../lib/rules/prefer-object-rule');
 const RuleTester = require('eslint').RuleTester;
 
-const ERROR = { messageId: 'preferObject', line: 2, column: 26 };
-
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -63,6 +61,18 @@ ruleTester.run('prefer-object-rule', rule, {
       };
       module.exports = rule;
     `,
+
+    {
+      // ESM
+      code: `
+        export default {
+          create(context) {
+            return { Program() { context.report() } };
+          },
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
   ],
 
   invalid: [
@@ -77,7 +87,7 @@ ruleTester.run('prefer-object-rule', rule, {
           return { Program() { context.report() } };
         }};
       `,
-      errors: [ERROR],
+      errors: [{ messageId: 'preferObject', line: 2, column: 26 }],
     },
     {
       code: `
@@ -90,7 +100,7 @@ ruleTester.run('prefer-object-rule', rule, {
           return { Program() { context.report() } };
         }};
       `,
-      errors: [ERROR],
+      errors: [{ messageId: 'preferObject', line: 2, column: 26 }],
     },
     {
       code: `
@@ -103,7 +113,35 @@ ruleTester.run('prefer-object-rule', rule, {
           return { Program() { context.report() } };
         }};
       `,
-      errors: [ERROR],
+      errors: [{ messageId: 'preferObject', line: 2, column: 26 }],
+    },
+
+    // ESM
+    {
+      code: `
+        export default function (context) {
+          return { Program() { context.report() } };
+        };
+      `,
+      output: `
+        export default {create(context) {
+          return { Program() { context.report() } };
+        }};
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'preferObject', line: 2, column: 24 }],
+    },
+    {
+      code: 'export default function create() {};',
+      output: 'export default {create() {}};',
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
+    },
+    {
+      code: 'export default () => {};',
+      output: 'export default {create: () => {}};',
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
     },
   ],
 });

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -34,6 +34,18 @@ ruleTester.run('report-message-format', rule, {
       options: ['foo'],
     },
     {
+      // ESM
+      code: `
+        export default {
+          create(context) {
+            context.report(node, 'foo');
+          }
+        };
+      `,
+      options: ['foo'],
+      parserOptions: { sourceType: 'module' },
+    },
+    {
       // With message as variable.
       code: `
         const MESSAGE = 'foo';
@@ -163,6 +175,18 @@ ruleTester.run('report-message-format', rule, {
         };
       `,
       options: ['foo'],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          create(context) {
+            context.report(node, 'bar');
+          }
+        };
+      `,
+      options: ['foo'],
+      parserOptions: { sourceType: 'module' },
     },
     {
       // With message as variable.

--- a/tests/lib/rules/require-meta-docs-description.js
+++ b/tests/lib/rules/require-meta-docs-description.js
@@ -21,6 +21,16 @@ ruleTester.run('require-meta-docs-description', rule, {
         create(context) {}
       };
     `,
+    {
+      // ESM
+      code: `
+        export default {
+          meta: { docs: { description: 'disallow unused variables' } },
+          create(context) {}
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     `
       module.exports = {
         meta: { docs: { description: 'enforce a maximum line length' } },
@@ -102,6 +112,18 @@ ruleTester.run('require-meta-docs-description', rule, {
         };
       `,
       output: null,
+      errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {},
+          create(context) {}
+        };
+      `,
+      output: null,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
     },
     {

--- a/tests/lib/rules/require-meta-docs-url.js
+++ b/tests/lib/rules/require-meta-docs-url.js
@@ -67,6 +67,20 @@ tester.run('require-meta-docs-url', rule, {
       }],
     },
     {
+      // ESM
+      filename: 'test-rule',
+      code: `
+        export default {
+          meta: {docs: {url: "path/to/test-rule.md"}},
+          create() {}
+        }
+      `,
+      options: [{
+        pattern: 'path/to/{{name}}.md',
+      }],
+      parserOptions: { sourceType: 'module' },
+    },
+    {
       // `url` in variable.
       filename: 'test-rule',
       code: `
@@ -535,6 +549,31 @@ url: "plugin-name/test.md"
       options: [{
         pattern: 'plugin-name/{{ name }}.md',
       }],
+      errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
+    },
+    {
+      // ESM
+      filename: 'test.js',
+      code: `
+        export default {
+          meta: {},
+          create() {}
+        }
+      `,
+      output: `
+        export default {
+          meta: {
+docs: {
+url: "plugin-name/test.md"
+}
+},
+          create() {}
+        }
+      `,
+      options: [{
+        pattern: 'plugin-name/{{ name }}.md',
+      }],
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
     },
     {

--- a/tests/lib/rules/require-meta-fixable.js
+++ b/tests/lib/rules/require-meta-fixable.js
@@ -34,6 +34,18 @@ ruleTester.run('require-meta-fixable', rule, {
         }
       };
     `,
+    {
+      // ESM
+      code: `
+        export default {
+          meta: { fixable: 'code' },
+          create(context) {
+            context.report({node, message, fix: foo});
+          }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     // Value in variable.
     `
       const fixable = 'code';
@@ -181,6 +193,17 @@ ruleTester.run('require-meta-fixable', rule, {
           create(context) { context.report({node, message, fix: foo}); }
         };
       `,
+      errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {},
+          create(context) { context.report({node, message, fix: foo}); }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
     },
     {

--- a/tests/lib/rules/require-meta-has-suggestions.js
+++ b/tests/lib/rules/require-meta-has-suggestions.js
@@ -112,6 +112,18 @@ ruleTester.run('require-meta-has-suggestions', rule, {
         }
       };
     `,
+    {
+      // ESM: Provides suggestions, has hasSuggestions property.
+      code: `
+        export default {
+          meta: { hasSuggestions: true },
+          create(context) {
+            context.report({node, message, suggest: [{}]});
+          }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     // Provides suggestions, has hasSuggestions property (as variable).
     `
       const hasSuggestions = true;
@@ -184,6 +196,17 @@ ruleTester.run('require-meta-has-suggestions', rule, {
         };
       `,
       output: null,
+      errors: [{ messageId: 'shouldBeSuggestable', type: 'FunctionExpression', line: 3, column: 17, endLine: 3, endColumn: 78 }],
+    },
+    {
+      // ESM: Reports suggestions, no meta object, violation should be on `create` function.
+      code: `
+        export default {
+          create(context) { context.report({node, message, suggest: [{}]}); }
+        };
+      `,
+      output: null,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'shouldBeSuggestable', type: 'FunctionExpression', line: 3, column: 17, endLine: 3, endColumn: 78 }],
     },
     {

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -53,6 +53,16 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) { const options = foo.options; }
       };
     `,
+    {
+    // ESM
+      code: `
+        export default {
+          meta: { schema: { "enum": ["always", "never"] } },
+          create(context) { const options = context.options; }
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     `
       const schema = [];
       module.exports = {
@@ -142,6 +152,36 @@ schema: []
               messageId: 'addEmptySchema',
               output: `
         module.exports = {
+          meta: {
+schema: []
+},
+          create(context) {}
+        };
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {},
+          create(context) {}
+        };
+      `,
+      output: null,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          suggestions: [
+            {
+              messageId: 'addEmptySchema',
+              output: `
+        export default {
           meta: {
 schema: []
 },

--- a/tests/lib/rules/require-meta-type.js
+++ b/tests/lib/rules/require-meta-type.js
@@ -25,6 +25,16 @@ ruleTester.run('require-meta-type', rule, {
         create(context) {}
       };
     `,
+    {
+      // ESM
+      code: `
+        export default {
+          meta: { type: 'problem' },
+          create(context) {}
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
     `
       module.exports = {
         meta: { type: 'suggestion' },
@@ -79,6 +89,17 @@ ruleTester.run('require-meta-type', rule, {
           create(context) {}
         };
       `,
+      errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {},
+          create(context) {}
+        };
+      `,
+      parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'missing', type: 'ObjectExpression' }],
     },
     {


### PR DESCRIPTION
Fixes #157. I recommend we add this to the upcoming v4 release (#120).

This change updates most rules (rules using our util `getRuleInfo` to read rule `create`/`meta` data) to support rules defined using the ES modules syntax as follows:

```js
export default {
  meta: {},
  create(context) {}
};
```

TODO:

- [x] Add tests for all affected rules.
- [x] ~~Support variables.~~ We've never supported this so I don't think it's essential now. We can follow-up to try to add it later if we want.
  ```
  const rule = { meta: {}, create(context) {} }; 
  export default rule;
  ```
- [x] Support `create` function as the default export.
