### PR TITLE
Fix: Remove erroneous schema from `require-meta-schema` rule

### DIFF
--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -16,17 +16,7 @@ module.exports = {
       recommended: false, // TODO: enable it in a major release.
     },
     fixable: 'code',
-    schema: [
-      {
-        type: 'object',
-        properties: {
-          exceptRange: {
-            type: 'boolean',
-          },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       foundOptionsUsage: '`meta.schema` has no schema defined but rule has options.',
       missing: '`meta.schema` is required (use [] if rule has no schema).',


### PR DESCRIPTION
Ironically, this rule had the wrong schema. This rule has no options and should not have an empty schema. The schema used here was supposed to be an example in the rule doc file only.