### PR TITLE
Fix: Only autofix when no options present in `require-meta-schema` rule

### DIFF
--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -51,6 +51,7 @@ module.exports = {
     const requireSchemaPropertyWhenOptionless = !context.options[0] || context.options[0].requireSchemaPropertyWhenOptionless;
 
     let hasEmptySchema = false;
+    let isUsingOptions = false;
 
     return {
       Program (ast) {
@@ -62,15 +63,6 @@ module.exports = {
           metaNode.properties.find(p => p.type === 'Property' && utils.getKeyName(p) === 'schema');
 
         if (!schemaNode) {
-          if (requireSchemaPropertyWhenOptionless) {
-            context.report({
-              node: metaNode,
-              messageId: 'missing',
-              fix (fixer) {
-                return utils.insertProperty(fixer, metaNode, 'schema: []', sourceCode);
-              },
-            });
-          }
           return;
         }
 
@@ -109,6 +101,21 @@ module.exports = {
         }
       },
 
+      'Program:exit' () {
+        if (!schemaNode && requireSchemaPropertyWhenOptionless) {
+          context.report({
+            node: metaNode,
+            messageId: 'missing',
+            fix (fixer) {
+              if (isUsingOptions) {
+                return null;
+              }
+              return utils.insertProperty(fixer, metaNode, 'schema: []', sourceCode);
+            },
+          });
+        }
+      },
+
       MemberExpression (node) {
         // Check if `context.options` was used when no options were defined in `meta.schema`.
         if (
@@ -118,6 +125,7 @@ module.exports = {
           node.property.type === 'Identifier' &&
           node.property.name === 'options'
         ) {
+          isUsingOptions = true;
           context.report({ node: schemaNode || metaNode, messageId: 'foundOptionsUsage' });
         }
       },

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -238,5 +238,19 @@ schema: [] },
       options: [{ requireSchemaPropertyWhenOptionless: false }],
       errors: [{ messageId: 'foundOptionsUsage', type: 'ObjectExpression' }],
     },
+    {
+      // No schema, but using rule options, should have no autofix.
+      code: `
+        module.exports = {
+          meta: {},
+          create(context) { const options = context.options; }
+        };
+      `,
+      output: null,
+      errors: [
+        { messageId: 'foundOptionsUsage', type: 'ObjectExpression' },
+        { messageId: 'missing', type: 'ObjectExpression' },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #182.

After this is merged, I will follow-up to convert the autofix to a suggestion, as per #183.