### PR TITLE
Breaking: Update `fixer-return` and `prefer-replace-text` rules to also apply to suggestion fixer functions

### DIFF
--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -98,22 +98,12 @@ module.exports = {
 
       // Stacks this function's information.
       onCodePathStart (codePath, node) {
-        const parent = node.parent;
-
-        // Whether we are inside the fixer function we care about.
-        const shouldCheck = ['FunctionExpression', 'ArrowFunctionExpression'].includes(node.type) &&
-          parent.parent.type === 'ObjectExpression' &&
-          parent.parent.parent.type === 'CallExpression' &&
-          contextIdentifiers.has(parent.parent.parent.callee.object) &&
-          parent.parent.parent.callee.property.name === 'report' &&
-          utils.getReportInfo(parent.parent.parent.arguments).fix === node;
-
         funcInfo = {
           upper: funcInfo,
           codePath,
           hasYieldWithFixer: false,
           hasReturnWithFixer: false,
-          shouldCheck,
+          shouldCheck: utils.isAutoFixerFunction(node, contextIdentifiers) || utils.isSuggestionFixerFunction(node, contextIdentifiers),
           node,
         };
       },

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -43,18 +43,10 @@ module.exports = {
 
       // Stacks this function's information.
       onCodePathStart (codePath, node) {
-        const parent = node.parent;
-        const shouldCheck = (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') &&
-          parent.parent.type === 'ObjectExpression' &&
-          parent.parent.parent.type === 'CallExpression' &&
-          contextIdentifiers.has(parent.parent.parent.callee.object) &&
-          parent.parent.parent.callee.property.name === 'report' &&
-          utils.getReportInfo(parent.parent.parent.arguments, context).fix === node;
-
         funcInfo = {
           upper: funcInfo,
           codePath,
-          shouldCheck,
+          shouldCheck: utils.isAutoFixerFunction(node, contextIdentifiers) || utils.isSuggestionFixerFunction(node, contextIdentifiers),
           node,
         };
       },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -424,4 +424,44 @@ module.exports = {
         ),
     ];
   },
+
+  /**
+   * Whether the provided node represents an autofixer function.
+   * @param {Node} node
+   * @param {Node[]} contextIdentifiers
+   * @returns {boolean}
+   */
+  isAutoFixerFunction (node, contextIdentifiers) {
+    const parent = node.parent;
+    return ['FunctionExpression', 'ArrowFunctionExpression'].includes(node.type) &&
+      parent.parent.type === 'ObjectExpression' &&
+      parent.parent.parent.type === 'CallExpression' &&
+      contextIdentifiers.has(parent.parent.parent.callee.object) &&
+      parent.parent.parent.callee.property.name === 'report' &&
+      module.exports.getReportInfo(parent.parent.parent.arguments).fix === node;
+  },
+
+  /**
+   * Whether the provided node represents a suggestion fixer function.
+   * @param {Node} node
+   * @param {Node[]} contextIdentifiers
+   * @returns {boolean}
+   */
+  isSuggestionFixerFunction (node, contextIdentifiers) {
+    const parent = node.parent;
+    return (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') &&
+      parent.type === 'Property' &&
+      parent.key.type === 'Identifier' &&
+      parent.key.name === 'fix' &&
+      parent.parent.type === 'ObjectExpression' &&
+      parent.parent.parent.type === 'ArrayExpression' &&
+      parent.parent.parent.parent.type === 'Property' &&
+      parent.parent.parent.parent.key.type === 'Identifier' &&
+      parent.parent.parent.parent.key.name === 'suggest' &&
+      parent.parent.parent.parent.parent.type === 'ObjectExpression' &&
+      parent.parent.parent.parent.parent.parent.type === 'CallExpression' &&
+      contextIdentifiers.has(parent.parent.parent.parent.parent.parent.callee.object) &&
+      parent.parent.parent.parent.parent.parent.callee.property.name === 'report' &&
+      module.exports.getReportInfo(parent.parent.parent.parent.parent.parent.arguments).suggest === parent.parent.parent;
+  },
 };

--- a/tests/lib/rules/fixer-return.js
+++ b/tests/lib/rules/fixer-return.js
@@ -221,6 +221,55 @@ ruleTester.run('fixer-return', rule, {
         }
     };
     `,
+
+    // Suggestion
+    `
+    module.exports = {
+        create: function(context) {
+            context.report( {
+                suggest: [
+                    {
+                        fix: function(fixer) {
+                            return fixer.foo();
+                        }
+                    }
+                ]
+            });
+        }
+    };
+    `,
+    // Suggestion but wrong `suggest` key
+    `
+    module.exports = {
+        create: function(context) {
+            context.report( {
+                notSuggest: [
+                    {
+                        fix: function(fixer) {
+                            fixer.foo();
+                        }
+                    }
+                ]
+            });
+        }
+    };
+    `,
+    // Suggestion but wrong `fix` key
+    `
+    module.exports = {
+        create: function(context) {
+            context.report( {
+                suggest: [
+                    {
+                        notFix: function(fixer) {
+                            fixer.foo();
+                        }
+                    }
+                ]
+            });
+        }
+    };
+    `,
   ],
 
   invalid: [
@@ -240,6 +289,25 @@ ruleTester.run('fixer-return', rule, {
       errors: [{ messageId: 'missingFix', type: 'FunctionExpression', line: 5, column: 24 }],
     },
     {
+      // Fix but missing return (suggestion)
+      code: `
+          module.exports = {
+              create: function(context) {
+                    context.report({
+                        suggest: [
+                            {
+                                fix(fixer) {
+                                    fixer.foo();
+                                }
+                            }
+                        ]
+                    });
+              }
+          };
+          `,
+      errors: [{ messageId: 'missingFix', type: 'FunctionExpression', line: 7, column: 36 }],
+    },
+    {
       // Fix but missing return (arrow function, report on arrow)
       code: `
         module.exports = {
@@ -253,6 +321,25 @@ ruleTester.run('fixer-return', rule, {
         };
         `,
       errors: [{ messageId: 'missingFix', type: 'ArrowFunctionExpression', line: 5, endLine: 5, column: 34, endColumn: 36 }],
+    },
+    {
+      // Fix but missing return (arrow function, report on arrow, suggestion)
+      code: `
+          module.exports = {
+                create: function(context) {
+                    context.report({
+                        suggest: [
+                            {
+                                fix: (fixer) => {
+                                    fixer.foo();
+                                }
+                            }
+                        ]
+                    });
+                }
+          };
+          `,
+      errors: [{ messageId: 'missingFix', type: 'ArrowFunctionExpression', line: 7, endLine: 7, column: 46, endColumn: 48 }],
     },
     {
       // With no autofix (arrow function, explicit return, report on arrow)

--- a/tests/lib/rules/prefer-replace-text.js
+++ b/tests/lib/rules/prefer-replace-text.js
@@ -17,8 +17,6 @@ const RuleTester = require('eslint').RuleTester;
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
-const ERROR = { messageId: 'useReplaceText', type: 'CallExpression' };
-
 
 ruleTester.run('prefer-placeholders', rule, {
   valid: [
@@ -52,6 +50,23 @@ ruleTester.run('prefer-placeholders', rule, {
     `
       fixer.replaceTextRange([node.range[0], node.range[1]], '');
     `,
+
+    // Suggestion
+    `
+      module.exports = {
+        create(context) {
+          context.report({
+            suggest: [
+              {
+                fix(fixer) {
+                  return fixer.replaceTextRange([start, end], '');
+                }
+              }
+            ]
+          });
+        }
+      };
+    `,
   ],
 
   invalid: [
@@ -67,7 +82,7 @@ ruleTester.run('prefer-placeholders', rule, {
           }
         };
     `,
-      errors: [ERROR],
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
     },
     {
       code: `
@@ -81,7 +96,7 @@ ruleTester.run('prefer-placeholders', rule, {
           }
         };
     `,
-      errors: [ERROR],
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
     },
     {
       code: `
@@ -95,7 +110,7 @@ ruleTester.run('prefer-placeholders', rule, {
           }
         };
     `,
-      errors: [ERROR],
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
     },
     {
       code: `
@@ -107,7 +122,7 @@ ruleTester.run('prefer-placeholders', rule, {
           }
         };
     `,
-      errors: [ERROR],
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
     },
     {
       code: `
@@ -121,7 +136,27 @@ ruleTester.run('prefer-placeholders', rule, {
           }
         };
     `,
-      errors: [ERROR],
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
+    },
+
+    {
+      // Suggestion fixer
+      code: `
+        module.exports = {
+          create(context) {
+            context.report({
+              suggest: [
+                {
+                  fix(fixer) {
+                    return fixer.replaceTextRange([node.range[0], node.range[1]], '');
+                  }
+                }
+              ]
+            });
+          }
+        };
+    `,
+      errors: [{ messageId: 'useReplaceText', type: 'CallExpression' }],
     },
   ],
 });


### PR DESCRIPTION
These rules should apply to both autofix and suggestion fixer functions.

Updating these two rules together since they share the same logic.

Fixes #193
Fixes #190

Part of v4 release (#120).