### PR TITLE
Breaking: Update `report-message-format` to also apply to suggestion messages

### DIFF
--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -83,12 +83,19 @@ module.exports = {
         ) {
           const reportInfo = utils.getReportInfo(node.arguments, context);
           const message = reportInfo && reportInfo.message;
+          const suggest = reportInfo && reportInfo.suggest;
 
-          if (!message) {
-            return;
+          if (message) {
+            processMessageNode(message);
           }
 
-          processMessageNode(message);
+          if (suggest && suggest.type === 'ArrayExpression') {
+            suggest.elements
+              .flatMap(obj => obj.properties)
+              .filter(prop => prop.type === 'Property' && prop.key.type === 'Identifier' && prop.key.name === 'message')
+              .map(prop => prop.value)
+              .forEach(processMessageNode);
+          }
         }
       },
     };

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -110,6 +110,28 @@ ruleTester.run('report-message-format', rule, {
       options: ['^foo$'],
     },
     {
+      // Suggestion message
+      code: `
+        module.exports = {
+          create(context) {
+            context.report({node, suggest: [{message: 'foo'}]});
+          }
+        };
+      `,
+      options: ['^foo$'],
+    },
+    {
+      // Suggestion message with ternary expression
+      code: `
+        module.exports = {
+          create(context) {
+            context.report({node, suggest: foo ? []: [{}]});
+          }
+        };
+      `,
+      options: ['^foo$'],
+    },
+    {
       code: `
         module.exports = {
           create(context) {
@@ -245,6 +267,17 @@ ruleTester.run('report-message-format', rule, {
         module.exports = {
           create(context) {
             context.report({node, message: \`FOO\`});
+          }
+        };
+      `,
+      options: ['foo'],
+    },
+    {
+      // Suggestion message
+      code: `
+        module.exports = {
+          create(context) {
+            context.report({node, suggest: [{message: 'FOO'}]});
           }
         };
       `,


### PR DESCRIPTION
Fixes #192.

Part of v4 release (#120).