### PR TITLE
Chore: upgrade dev deps (fixes #188)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "espree": "^7.3.0",
     "estraverse": "^5.0.0",
     "lodash": "^4.17.2",
-    "markdownlint-cli": "^0.27.1",
-    "mocha": "^7.1.1",
+    "markdownlint-cli": "^0.28.1",
+    "mocha": "^9.1.2",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0"
   },


### PR DESCRIPTION
espree and eslint-scope has been upgrade in https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/186, to ensure the same version as eslint v8.0.0

fixes #188 