### PR TITLE
Breaking: Add `fixer-return` to `rules` preset

### DIFF
--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -21,7 +21,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'require fixer functions to return a fix',
-      category: 'Possible Errors',
+      category: 'Rules',
       recommended: true,
     },
     fixable: null,

--- a/tests/lib/rule-setup.js
+++ b/tests/lib/rule-setup.js
@@ -37,6 +37,18 @@ describe('rule setup is correct', () => {
     );
   });
 
+  describe('rule files', () => {
+    for (const ruleName of RULE_NAMES) {
+      const rule = plugin.rules[ruleName];
+      describe(ruleName, () => {
+        it('has the right properties', () => {
+          const ALLOWED_CATEGORIES = ['Rules', 'Tests'];
+          assert.ok(ALLOWED_CATEGORIES.includes(rule.meta.docs.category), 'has an allowed category');
+        });
+      });
+    }
+  });
+
   it('should have tests for all rules', () => {
     const filePath = path.join(__dirname, 'rules');
     const files = readdirSync(filePath);


### PR DESCRIPTION
All rules should have a category of either `Rules` or `Tests` since this is how those presets are generated.

Technically, this isn't a breaking change, since we're allowed to modify these presets any time, according to the README:

> The list of recommended rules will only change in a major release of this plugin. However, new non-recommended rules might be added in a minor release of this plugin. Therefore, the using the all, rules, and tests presets is not recommended for production use, because the addition of new rules in a minor release could break your build. 

Part of v4 release (#120).