### PR TITLE
Chore: Fix markdownlint glob path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
-    "lint:docs": "markdownlint **/*.md",
+    "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint .",
     "generate-readme-table": "node build/generate-readme-table.js",
     "generate-release": "release-it",


### PR DESCRIPTION
Quotes around the glob is necessary to ensure it picks up all files in this case.

Another example of this: https://github.com/ember-template-lint/ember-template-lint/pull/2124