### PR TITLE
Upgrade: `eslint-plugin-unicorn` to v37

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-markdown": "^2.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-self": "^1.2.1",
-    "eslint-plugin-unicorn": "github:fisker/eslint-plugin-unicorn#eslint-8",
+    "eslint-plugin-unicorn": "^37.0.0",
     "eslint-scope": "^6.0.0",
     "espree": "^9.0.0",
     "estraverse": "^5.0.0",


### PR DESCRIPTION
It has official ESLint v8 support: https://github.com/sindresorhus/eslint-plugin-unicorn/releases/tag/v37.0.0