### PR TITLE
Docs: Move preset list into table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,3 @@ Or to apply linting only to the appropriate rule or test files:
     ]
 }
 ```
-
-* `recommended` enables all recommended rules from this plugin.
-* `rules-recommended` enables all recommended rules that are aimed at linting ESLint rule files.
-* `tests-recommended` enables all recommended rules that are aimed at linting ESLint test files.
-
-* `all` enables all rules in this plugin.
-* `rules` enables all rules that are aimed at linting ESLint rule files.
-* `tests` enables all rules that are aimed at linting ESLint test files.
-
-The list of recommended rules will only change in a major release of this plugin. However, new non-recommended rules might be added in a minor release of this plugin. Therefore, the using the `all`, `rules`, and `tests` presets is **not recommended for production use**, because the addition of new rules in a minor release could break your build.


### PR DESCRIPTION
Many other ESLint plugins use a table for listing presets/configs (similar to the rules table):
* https://github.com/ember-cli/eslint-plugin-ember#-configurations
* https://github.com/ember-template-lint/ember-template-lint#presets
* https://github.com/platinumazure/eslint-plugin-qunit#configurations 