### PR TITLE
Breaking: Reduce false positives by only detecting function-style rules when the function returns an object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { getStaticValue } = require('eslint-utils');
+const estraverse = require('estraverse');
 
 /**
 * Determines whether a node is a 'normal' (i.e. non-async, non-generator) function expression.
@@ -103,6 +104,24 @@ function collectInterestingProperties (properties, interestingKeys) {
 }
 
 /**
+ * Check if there is a return statement that returns an object somewhere inside the given node.
+ * @param {Node} node
+ * @returns {boolean}
+ */
+function hasObjectReturn (node) {
+  let foundMatch = false;
+  estraverse.traverse(node, {
+    enter (child) {
+      if (child.type === 'ReturnStatement' && child.argument && child.argument.type === 'ObjectExpression') {
+        foundMatch = true;
+      }
+    },
+    fallback: 'iteration', // Don't crash on unexpected node types.
+  });
+  return foundMatch;
+}
+
+/**
  * Helper for `getRuleInfo`. Handles ESM and TypeScript rules.
  */
 function getRuleExportsESM (ast) {
@@ -114,8 +133,8 @@ function getRuleExportsESM (ast) {
       if (node.type === 'ObjectExpression') {
         // Check `export default { create() {}, meta: {} }`
         return collectInterestingProperties(node.properties, INTERESTING_RULE_KEYS);
-      } else if (isNormalFunctionExpression(node)) {
-        // Check `export default function() {}`
+      } else if (isNormalFunctionExpression(node) && hasObjectReturn(node)) {
+        // Check `export default function() { return { ... }; }`
         return { create: node, meta: null, isNewStyle: false };
       } else if (
         node.type === 'CallExpression' &&
@@ -156,8 +175,8 @@ function getRuleExportsCJS (ast) {
         node.left.property.type === 'Identifier' && node.left.property.name === 'exports'
       ) {
         exportsVarOverridden = true;
-        if (isNormalFunctionExpression(node.right)) {
-          // Check `module.exports = function () {}`
+        if (isNormalFunctionExpression(node.right) && hasObjectReturn(node.right)) {
+          // Check `module.exports = function () { return {}; }`
 
           exportsIsFunction = true;
           return { create: node.right, meta: null, isNewStyle: false };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin#readme",
   "dependencies": {
-    "eslint-utils": "^3.0.0"
+    "eslint-utils": "^3.0.0",
+    "estraverse": "^5.2.0"
   },
   "nyc": {
     "branches": 98,
@@ -51,7 +52,6 @@
     "eslint-plugin-unicorn": "^37.0.0",
     "eslint-scope": "^6.0.0",
     "espree": "^9.0.0",
-    "estraverse": "^5.0.0",
     "lodash": "^4.17.2",
     "markdownlint-cli": "^0.28.1",
     "mocha": "^9.1.2",

--- a/tests/lib/rules/no-deprecated-context-methods.js
+++ b/tests/lib/rules/no-deprecated-context-methods.js
@@ -30,8 +30,8 @@ ruleTester.run('no-deprecated-context-methods', rule, {
     `
     module.exports = context => {
       const sourceCode = context.getSourceCode();
-
       sourceCode.getFirstToken();
+      return {};
     }
   `,
   ],
@@ -70,12 +70,12 @@ ruleTester.run('no-deprecated-context-methods', rule, {
     {
       code: `
         module.exports = myRuleContext => {
-          myRuleContext.getFirstToken;
+          myRuleContext.getFirstToken; return {};
         }
       `,
       output: `
         module.exports = myRuleContext => {
-          myRuleContext.getSourceCode().getFirstToken;
+          myRuleContext.getSourceCode().getFirstToken; return {};
         }
       `,
       errors: [

--- a/tests/lib/rules/no-deprecated-report-api.js
+++ b/tests/lib/rules/no-deprecated-report-api.js
@@ -39,12 +39,12 @@ ruleTester.run('no-deprecated-report-api', rule, {
     `,
     `
       module.exports = function(context) {
-        context.report({node, message: "Foo"});
+        context.report({node, message: "Foo"}); return {};
       };
     `,
     `
       module.exports = (context) => {
-        context.report({node, message: "Foo"});
+        context.report({node, message: "Foo"}); return {};
       };
     `,
     `

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -84,12 +84,12 @@ ruleTester.run('no-missing-placeholders', rule, {
     `,
     `
       module.exports = context => {
-        context.report(node, 'foo {{bar}}', { bar: 'baz' });
+        context.report(node, 'foo {{bar}}', { bar: 'baz' }); return {};
       };
     `,
     `
       module.exports = context => {
-        context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { bar: 'baz' });
+        context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { bar: 'baz' }); return {};
       };
     `,
     `
@@ -118,14 +118,14 @@ ruleTester.run('no-missing-placeholders', rule, {
     `
       const MESSAGE = 'foo {{bar}}';
       module.exports = context => {
-        context.report(node, MESSAGE, { bar: 'baz' });
+        context.report(node, MESSAGE, { bar: 'baz' }); return {};
       };
     `,
     // Message in variable but cannot statically determine its type.
     `
       const MESSAGE = getMessage();
       module.exports = context => {
-        context.report(node, MESSAGE, { baz: 'qux' });
+        context.report(node, MESSAGE, { baz: 'qux' }); return {};
       };
     `,
     // Suggestion with placeholder
@@ -193,7 +193,7 @@ ruleTester.run('no-missing-placeholders', rule, {
     {
       code: `
         module.exports = context => {
-          context.report(node, 'foo {{bar}}', { baz: 'qux' });
+          context.report(node, 'foo {{bar}}', { baz: 'qux' }); return {};
         };
       `,
       errors: [error('bar')],
@@ -203,7 +203,7 @@ ruleTester.run('no-missing-placeholders', rule, {
       code: `
         const MESSAGE = 'foo {{bar}}';
         module.exports = context => {
-          context.report(node, MESSAGE, { baz: 'qux' });
+          context.report(node, MESSAGE, { baz: 'qux' }); return {};
         };
       `,
       errors: [error('bar', 'Identifier')],
@@ -211,7 +211,7 @@ ruleTester.run('no-missing-placeholders', rule, {
     {
       code: `
         module.exports = context => {
-          context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { baz: 'baz' });
+          context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { baz: 'baz' }); return {};
         };
       `,
       errors: [error('bar')],

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -85,26 +85,26 @@ ruleTester.run('no-unused-placeholders', rule, {
     `,
     `
       module.exports = context => {
-        context.report(node, 'foo {{bar}}', { bar: 'baz' });
+        context.report(node, 'foo {{bar}}', { bar: 'baz' }); return {};
       };
     `,
     // With message as variable.
     `
       const MESSAGE = 'foo {{bar}}';
       module.exports = context => {
-        context.report(node, MESSAGE, { bar: 'baz' });
+        context.report(node, MESSAGE, { bar: 'baz' }); return {};
       };
     `,
     // With message as variable but cannot statically determine its type.
     `
       const MESSAGE = getMessage();
       module.exports = context => {
-        context.report(node, MESSAGE, { bar: 'baz' });
+        context.report(node, MESSAGE, { bar: 'baz' }); return {};
       };
     `,
     `
       module.exports = context => {
-        context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { bar: 'baz' });
+        context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { bar: 'baz' }); return {};
       };
     `,
     // Suggestion

--- a/tests/lib/rules/prefer-object-rule.js
+++ b/tests/lib/rules/prefer-object-rule.js
@@ -132,14 +132,14 @@ ruleTester.run('prefer-object-rule', rule, {
       errors: [{ messageId: 'preferObject', line: 2, column: 24 }],
     },
     {
-      code: 'export default function create() {};',
-      output: 'export default {create() {}};',
+      code: 'export default function create() { return {}; };',
+      output: 'export default {create() { return {}; }};',
       parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
     },
     {
-      code: 'export default () => {};',
-      output: 'export default {create: () => {}};',
+      code: 'export default () => { return {}; };',
+      output: 'export default {create: () => { return {}; }};',
       parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
     },

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -22,7 +22,7 @@ ruleTester.run('report-message-format', rule, {
 
   valid: [
     // with no configuration, everything is allowed
-    'module.exports = context => context.report(node, "foo");',
+    'module.exports = context => { context.report(node, "foo"); return {}; }',
     {
       code: `
         module.exports = {

--- a/tests/lib/rules/require-meta-docs-url.js
+++ b/tests/lib/rules/require-meta-docs-url.js
@@ -125,7 +125,7 @@ tester.run('require-meta-docs-url', rule, {
   invalid: [
     {
       code: `
-        module.exports = function() {}
+        module.exports = function() { return {}; }
       `,
       output: null,
       errors: [{ messageId: 'missing', type: 'FunctionExpression' }],
@@ -310,7 +310,7 @@ tester.run('require-meta-docs-url', rule, {
     // -------------------------------------------------------------------------
     {
       code: `
-        module.exports = function() {}
+        module.exports = function() { return {}; }
       `,
       output: null,
       options: [{
@@ -492,7 +492,7 @@ tester.run('require-meta-docs-url', rule, {
     {
       filename: 'test.js',
       code: `
-        module.exports = function() {}
+        module.exports = function() { return {}; }
       `,
       output: null,
       options: [{

--- a/tests/lib/rules/require-meta-fixable.js
+++ b/tests/lib/rules/require-meta-fixable.js
@@ -25,7 +25,7 @@ ruleTester.run('require-meta-fixable', rule, {
         create(context) {}
       };
     `,
-    'module.exports = context => {};',
+    'module.exports = context => { return {}; };',
     `
       module.exports = {
         meta: { fixable: 'code' },

--- a/tests/lib/rules/require-meta-has-suggestions.js
+++ b/tests/lib/rules/require-meta-has-suggestions.js
@@ -14,7 +14,7 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run('require-meta-has-suggestions', rule, {
   valid: [
-    'module.exports = context => {};',
+    'module.exports = context => { return {}; };',
     // No suggestions reported, no violations reported, no meta object.
     `
       module.exports = {


### PR DESCRIPTION
Fixes #210.

When detecting the deprecated, function-style rule, we can be more strict and only detect default exports with a function *that returns an object*.

```js
module.exports = function(context) {
    return {
        CallExpression(node) {}
    };
};
```

This will help reduce false positives which could previously happen with detecting default exports of arbitrary functions.

I implemented this for both CJS (pre-v4) and ESM (v4+) rules. We might as well be more strict for all function-style rules, given that they are deprecated and rare anyway (only about 6% of rules are function-style according to an [analysis](https://github.com/eslint/eslint/issues/14709#issuecomment-874900196) I performed).

https://eslint.org/docs/developer-guide/working-with-rules-deprecated

Part of v4 release (#120).