### PR TITLE
Fix: Only consider functions with a single argument as function-style rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,6 +122,19 @@ function hasObjectReturn (node) {
 }
 
 /**
+ * Determine if the given node is likely to be a function-style rule.
+ * @param {*} node
+ * @returns {boolean}
+ */
+function isFunctionRule (node) {
+  return (
+    isNormalFunctionExpression(node) && // Is a function definition.
+    node.params.length === 1 && // The function has a single `context` argument.
+    hasObjectReturn(node) // Returns an object containing the visitor functions.
+  );
+}
+
+/**
  * Helper for `getRuleInfo`. Handles ESM and TypeScript rules.
  */
 function getRuleExportsESM (ast) {
@@ -133,8 +146,8 @@ function getRuleExportsESM (ast) {
       if (node.type === 'ObjectExpression') {
         // Check `export default { create() {}, meta: {} }`
         return collectInterestingProperties(node.properties, INTERESTING_RULE_KEYS);
-      } else if (isNormalFunctionExpression(node) && hasObjectReturn(node)) {
-        // Check `export default function() { return { ... }; }`
+      } else if (isFunctionRule(node)) {
+        // Check `export default function(context) { return { ... }; }`
         return { create: node, meta: null, isNewStyle: false };
       } else if (
         node.type === 'CallExpression' &&
@@ -175,8 +188,8 @@ function getRuleExportsCJS (ast) {
         node.left.property.type === 'Identifier' && node.left.property.name === 'exports'
       ) {
         exportsVarOverridden = true;
-        if (isNormalFunctionExpression(node.right) && hasObjectReturn(node.right)) {
-          // Check `module.exports = function () { return {}; }`
+        if (isFunctionRule(node.right)) {
+          // Check `module.exports = function (context) { return { ... }; }`
 
           exportsIsFunction = true;
           return { create: node.right, meta: null, isNewStyle: false };

--- a/tests/lib/rules/prefer-object-rule.js
+++ b/tests/lib/rules/prefer-object-rule.js
@@ -132,14 +132,14 @@ ruleTester.run('prefer-object-rule', rule, {
       errors: [{ messageId: 'preferObject', line: 2, column: 24 }],
     },
     {
-      code: 'export default function create() { return {}; };',
-      output: 'export default {create() { return {}; }};',
+      code: 'export default function create(context) { return {}; };',
+      output: 'export default {create(context) { return {}; }};',
       parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
     },
     {
-      code: 'export default () => { return {}; };',
-      output: 'export default {create: () => { return {}; }};',
+      code: 'export default (context) => { return {}; };',
+      output: 'export default {create: (context) => { return {}; }};',
       parserOptions: { sourceType: 'module' },
       errors: [{ messageId: 'preferObject', line: 1, column: 16 }],
     },

--- a/tests/lib/rules/require-meta-docs-url.js
+++ b/tests/lib/rules/require-meta-docs-url.js
@@ -125,7 +125,7 @@ tester.run('require-meta-docs-url', rule, {
   invalid: [
     {
       code: `
-        module.exports = function() { return {}; }
+        module.exports = function(context) { return {}; }
       `,
       output: null,
       errors: [{ messageId: 'missing', type: 'FunctionExpression' }],
@@ -310,7 +310,7 @@ tester.run('require-meta-docs-url', rule, {
     // -------------------------------------------------------------------------
     {
       code: `
-        module.exports = function() { return {}; }
+        module.exports = function(context) { return {}; }
       `,
       output: null,
       options: [{
@@ -492,7 +492,7 @@ tester.run('require-meta-docs-url', rule, {
     {
       filename: 'test.js',
       code: `
-        module.exports = function() { return {}; }
+        module.exports = function(context) { return {}; }
       `,
       output: null,
       options: [{


### PR DESCRIPTION
I did some further real-world testing and found another heuristic we can use to ensure we only detect actual function-style rules (reducing false positives).

All function-styles rules should have the single `context` argument. This is needed so the rule can use `context.report(...)` to report violations.

Note that while we are now checking for a single argument, we are not checking anything about this argument, as it could have different names (doesn't have to be named `context`) or could use destructuring if desired.

This idea was also suggested here: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/81#issuecomment-489914819

Fixes #81.

Part of v4 release (#120).

https://eslint.org/docs/developer-guide/working-with-rules-deprecated