### PR TITLE
Fix: Avoid crash when provided suggestions array has non-object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -467,14 +467,17 @@ module.exports = {
       // Suggestion messages
       ...((reportInfo.suggest && reportInfo.suggest.elements) || [])
         .map(suggestObjNode => {
+          if (suggestObjNode.type !== 'ObjectExpression') {
+            // Ignore non-objects (like variables or function calls).
+            return null;
+          }
           return {
             messageId: findObjectPropertyValueByKeyName(suggestObjNode, 'messageId'),
             message: findObjectPropertyValueByKeyName(suggestObjNode, 'desc'), // Note: suggestion message named `desc`
             data: findObjectPropertyValueByKeyName(suggestObjNode, 'data'),
             fix: findObjectPropertyValueByKeyName(suggestObjNode, 'fix'),
           };
-        }
-        ),
+        }).filter(item => item !== null),
     ];
   },
 

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -626,6 +626,7 @@ describe('utils', () => {
   describe('collectReportViolationAndSuggestionData', () => {
     const CASES = [
       {
+        // One suggestion.
         code: `
           context.report({
             node: {},
@@ -652,6 +653,68 @@ describe('utils', () => {
             message: { type: 'Literal', value: 'message2' },
             messageId: { type: 'Literal', value: 'messageId2' },
             data: { type: 'ObjectExpression', properties: [{ key: { name: 'bar' } }] },
+            fix: { type: 'FunctionExpression' },
+          },
+        ],
+      },
+      {
+        // Suggestions using an array variable.
+        code: `
+          context.report({
+            node: {},
+            message: "message1",
+            messageId: "messageId1",
+            data: { foo: 'hello' },
+            fix(fixer) {},
+            suggest: SUGGESTIONS
+          });
+        `,
+        shouldMatch: [
+          {
+            message: { type: 'Literal', value: 'message1' },
+            messageId: { type: 'Literal', value: 'messageId1' },
+            data: { type: 'ObjectExpression', properties: [{ key: { name: 'foo' } }] },
+            fix: { type: 'FunctionExpression' },
+          },
+        ],
+      },
+      {
+        // Suggestions using array item variables.
+        code: `
+          context.report({
+            node: {},
+            message: "message1",
+            messageId: "messageId1",
+            data: { foo: 'hello' },
+            fix(fixer) {},
+            suggest: [ SUGGEST_1, SUGGEST_2 ]
+          });
+        `,
+        shouldMatch: [
+          {
+            message: { type: 'Literal', value: 'message1' },
+            messageId: { type: 'Literal', value: 'messageId1' },
+            data: { type: 'ObjectExpression', properties: [{ key: { name: 'foo' } }] },
+            fix: { type: 'FunctionExpression' },
+          },
+        ],
+      },
+      {
+        // No suggestions.
+        code: `
+          context.report({
+            node: {},
+            message: "message1",
+            messageId: "messageId1",
+            data: { foo: 'hello' },
+            fix(fixer) {},
+          });
+        `,
+        shouldMatch: [
+          {
+            message: { type: 'Literal', value: 'message1' },
+            messageId: { type: 'Literal', value: 'messageId1' },
+            data: { type: 'ObjectExpression', properties: [{ key: { name: 'foo' } }] },
             fix: { type: 'FunctionExpression' },
           },
         ],


### PR DESCRIPTION
Fixes #215.

```
    TypeError: Cannot read property 'find' of undefined
    Occurred while linting /home/runner/work/eslint-plugin-jest/eslint-plugin-jest/src/rules/prefer-expect-assertions.ts:163
    Rule: "eslint-plugin/no-missing-placeholders"

      at findObjectPropertyValueByKeyName (node_modules/eslint-plugin-eslint-plugin/lib/utils.js:232:35)
          at Array.map (<anonymous>)
          at Array.forEach (<anonymous>)
```