### PR TITLE
Fix: Handle `meta: {} as const` for TypeScript rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -97,7 +97,8 @@ function collectInterestingProperties (properties, interestingKeys) {
   return properties.reduce((parsedProps, prop) => {
     const keyValue = module.exports.getKeyName(prop);
     if (interestingKeys.has(keyValue)) {
-      parsedProps[keyValue] = prop.value;
+      // In TypeScript, unwrap any usage of `{} as const`.
+      parsedProps[keyValue] = prop.value.type === 'TSAsExpression' ? prop.value.expression : prop.value;
     }
     return parsedProps;
   }, {});

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -139,6 +139,13 @@ describe('utils', () => {
           isNewStyle: true,
         },
 
+        // Util function with "{} as const".
+        'export default createESLintRule({ create() {}, meta: {} as const });': {
+          create: { type: 'FunctionExpression' },
+          meta: { type: 'ObjectExpression' },
+          isNewStyle: true,
+        },
+
         // Util function from util object
         'export default util.createRule<Options, MessageIds>({ create() {}, meta: {} });': {
           create: { type: 'FunctionExpression' },


### PR DESCRIPTION
Some TypeScript rules are written with `meta: {} as const`:

```js
export default createRule({
  meta: {
    type: 'suggestion',
    schema: []
  } as const,
});
```

https://github.com/jest-community/eslint-plugin-jest/blob/973e2b564600ef047ff66bb812c940770ef7627c/src/rules/prefer-lowercase-title.ts#L105

We have to unwrap the `as const` expression to get the `meta` object.

Fixes #214.