### PR TITLE
Ensure rule docs mention all rule options

### DIFF
--- a/docs/rules/require-meta-docs-url.md
+++ b/docs/rules/require-meta-docs-url.md
@@ -8,20 +8,6 @@ A rule can store the URL to its documentation page in `meta.docs.url`. This enab
 
 This rule aims to require ESLint rules to have a `meta.docs.url` property.
 
-This rule has an option.
-
-```json
-{
-  "eslint-plugin/require-meta-docs-url": ["error", {
-    "pattern": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/{{name}}.md"
-  }]
-}
-```
-
-- `pattern` (`string`) ... A pattern to enforce rule's document URL. It replaces `{{name}}` placeholder by each rule name. The rule name is the basename of each rule file. Default is `undefined` which allows any URL.
-
-If you set the `pattern` option, this rule adds `meta.docs.url` property automatically when you execute `eslint --fix` command.
-
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -96,6 +82,22 @@ module.exports = {
 };
 
 ```
+
+## Options
+
+This rule has an option.
+
+```json
+{
+  "eslint-plugin/require-meta-docs-url": ["error", {
+    "pattern": "https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/{{name}}.md"
+  }]
+}
+```
+
+- `pattern` (`string`) ... A pattern to enforce rule's document URL. It replaces `{{name}}` placeholder by each rule name. The rule name is the basename of each rule file. Default is `undefined` which allows any URL.
+
+If you set the `pattern` option, this rule adds `meta.docs.url` property automatically when you execute `eslint --fix` command.
 
 ## Version specific URL
 


### PR DESCRIPTION
Add test to ensure:

1. Any rule with options has a `## Options` section in its rule doc.
2. Any named rule options (for example, the `pattern` option for the `require-meta-docs-description` rule) are mentioned in the rule doc.

Based on the same test I wrote here: https://github.com/ember-cli/eslint-plugin-ember/blob/4f26c0bc7e34400007e02939a9c6e183078a3e87/tests/rule-setup.js#L111

Eventually, I'd like to add a lint rule to enforce these "rule setup" tests for any eslint plugin.