### PR TITLE
Add jsdoc `type` annotation to rules

### DIFF
--- a/lib/rules/consistent-output.js
+++ b/lib/rules/consistent-output.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/fixer-return.js
+++ b/lib/rules/fixer-return.js
@@ -16,6 +16,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -10,6 +10,7 @@ const { getKeyName, getRuleInfo } = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-deprecated-context-methods.js
+++ b/lib/rules/no-deprecated-context-methods.js
@@ -34,6 +34,7 @@ const DEPRECATED_PASSTHROUGHS = {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-deprecated-report-api.js
+++ b/lib/rules/no-deprecated-report-api.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/no-identical-tests.js
+++ b/lib/rules/no-identical-tests.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -12,6 +12,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-only-tests.js
+++ b/lib/rules/no-only-tests.js
@@ -3,6 +3,7 @@
 const utils = require('../utils');
 const { isCommaToken, isOpeningBraceToken, isClosingBraceToken } = require('eslint-utils');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -12,6 +12,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/no-useless-token-range.js
+++ b/lib/rules/no-useless-token-range.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/prefer-message-ids.js
+++ b/lib/rules/prefer-message-ids.js
@@ -7,6 +7,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -10,6 +10,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/prefer-output-null.js
+++ b/lib/rules/prefer-output-null.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/prefer-placeholders.js
+++ b/lib/rules/prefer-placeholders.js
@@ -12,6 +12,7 @@ const { findVariable } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/prefer-replace-text.js
+++ b/lib/rules/prefer-replace-text.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -12,6 +12,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -9,6 +9,7 @@ const utils = require('../utils');
 
 const DEFAULT_PATTERN = new RegExp('^(enforce|require|disallow)');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -16,6 +16,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // -----------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -12,6 +12,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -7,6 +7,7 @@ const { getStaticValue } = require('eslint-utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -7,6 +7,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/require-meta-type.js
+++ b/lib/rules/require-meta-type.js
@@ -13,6 +13,7 @@ const VALID_TYPES = new Set(['problem', 'suggestion', 'layout']);
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/lib/rules/test-case-property-ordering.js
+++ b/lib/rules/test-case-property-ordering.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/test-case-shorthand-strings.js
+++ b/lib/rules/test-case-shorthand-strings.js
@@ -11,6 +11,7 @@ const utils = require('../utils');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',


### PR DESCRIPTION
Supported by VSCode/Webstorm/other code editors. Uses TypeScript declaration to give JavaScript hints so code editors can provide information/autocomplete about various rule fields.

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#type

Idea from: https://github.com/eslint/generator-eslint/pull/113

<img width="391" alt="133895350-a19d0daf-593e-44b9-835f-bebf8b6a3d30" src="https://user-images.githubusercontent.com/698306/141347890-31e7f482-2b46-4ded-921b-d425350e4d36.png">
