### PR TITLE
Add dependency caching to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
       - run: npm install
       - run: npm test
 
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "16.x"
+          cache: "npm"
       - run: npm install
       - run: npm run lint
 
@@ -43,6 +45,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: "16.x"
+        cache: "npm"
     - run: npm install
     - run: npm install --save-dev eslint@6
     - run: npm test
@@ -54,6 +57,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: "16.x"
+        cache: "npm"
     - run: npm install
     - run: npm install --save-dev eslint@7
     - run: npm test


### PR DESCRIPTION
Quick PR to add dependency caching to CI, which should speed up CI by at least a few seconds.

References:

* https://github.com/actions/setup-node#caching-packages-dependencies