### PR TITLE
Upgrade actions used in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -29,8 +29,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
       - run: npm install
@@ -39,8 +39,8 @@ jobs:
   eslint6:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: "16.x"
     - run: npm install
@@ -50,8 +50,8 @@ jobs:
   eslint7:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: "16.x"
     - run: npm install


### PR DESCRIPTION
Quick PR to upgrade `actions/checkout` and `actions/setup-node` to `v3`.

## Acceptance criteria
- [ ] CI passes.

https://github.com/actions/checkout/releases/tag/v3.0.0
https://github.com/actions/setup-node/releases/tag/v3.0.0