### PR TITLE
Fix: Detect nested test cases

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -414,9 +414,22 @@ module.exports = {
 
     for (const statement of statements) {
       if (statement.type === 'VariableDeclaration') {
-        statement.declarations.forEach((declarator) => {
+        for (const declarator of statement.declarations) {
+          if (!declarator.init) {
+            continue;
+          }
+
+          const extracted = module.exports.extractFunctionBody(declarator.init);
+
+          runCalls.push(
+            ...module.exports.checkStatementsForTestInfo(
+              context,
+              extracted,
+              variableIdentifiers
+            )
+          );
+
           if (
-            declarator.init &&
             isRuleTesterConstruction(declarator.init) &&
             declarator.id.type === 'Identifier'
           ) {
@@ -426,7 +439,7 @@ module.exports = {
                 .forEach((ref) => variableIdentifiers.add(ref.identifier));
             });
           }
-        });
+        }
       }
 
       if (statement.type === 'IfStatement') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -384,11 +384,14 @@ module.exports = {
    */
   extractFunctionBody(node) {
     if (
-      (node.type === 'ArrowFunctionExpression' ||
-        node.type === 'FunctionExpression') &&
-      node.body.type === 'BlockStatement'
+      node.type === 'ArrowFunctionExpression' ||
+      node.type === 'FunctionExpression'
     ) {
-      return node.body.body;
+      if (node.body.type === 'BlockStatement') {
+        return node.body.body;
+      }
+
+      return [node.body];
     }
 
     return [];
@@ -426,14 +429,16 @@ module.exports = {
         });
       }
 
-      if (
-        statement.type !== 'ExpressionStatement' ||
-        statement.expression.type !== 'CallExpression'
-      ) {
+      const expression =
+        statement.type === 'ExpressionStatement'
+          ? statement.expression
+          : statement;
+
+      if (expression.type !== 'CallExpression') {
         continue;
       }
 
-      for (const arg of statement.expression.arguments) {
+      for (const arg of expression.arguments) {
         const extracted = module.exports.extractFunctionBody(arg);
 
         runCalls.push(
@@ -446,13 +451,13 @@ module.exports = {
       }
 
       if (
-        statement.expression.callee.type === 'MemberExpression' &&
-        (isRuleTesterConstruction(statement.expression.callee.object) ||
-          variableIdentifiers.has(statement.expression.callee.object)) &&
-        statement.expression.callee.property.type === 'Identifier' &&
-        statement.expression.callee.property.name === 'run'
+        expression.callee.type === 'MemberExpression' &&
+        (isRuleTesterConstruction(expression.callee.object) ||
+          variableIdentifiers.has(expression.callee.object)) &&
+        expression.callee.property.type === 'Identifier' &&
+        expression.callee.property.name === 'run'
       ) {
-        runCalls.push(statement.expression);
+        runCalls.push(expression);
       }
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -442,6 +442,16 @@ module.exports = {
         }
       }
 
+      if (statement.type === 'FunctionDeclaration') {
+        runCalls.push(
+          ...module.exports.checkStatementsForTestInfo(
+            context,
+            statement.body.body,
+            variableIdentifiers
+          )
+        );
+      }
+
       if (statement.type === 'IfStatement') {
         const body =
           statement.consequent.type === 'BlockStatement'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -429,6 +429,23 @@ module.exports = {
         });
       }
 
+      if (statement.type === 'IfStatement') {
+        const body =
+          statement.consequent.type === 'BlockStatement'
+            ? statement.consequent.body
+            : [statement.consequent];
+
+        runCalls.push(
+          ...module.exports.checkStatementsForTestInfo(
+            context,
+            body,
+            variableIdentifiers
+          )
+        );
+
+        continue;
+      }
+
       const expression =
         statement.type === 'ExpressionStatement'
           ? statement.expression

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -377,16 +377,39 @@ module.exports = {
   },
 
   /**
-   * Performs static analysis on an AST to try to find test cases
-   * @param {RuleContext} context The `context` variable for the source file itself
-   * @param {ASTNode} ast The `Program` node for the file.
-   * @returns {object} An object with `valid` and `invalid` keys containing a list of AST nodes corresponding to tests
+   * Extracts the body of a function if the given node is a function
+   *
+   * @param {ASTNode} node
+   * @returns {ExpressionStatement[]}
    */
-  getTestInfo(context, ast) {
-    const runCalls = [];
-    const variableIdentifiers = new Set();
+  extractFunctionBody(node) {
+    if (
+      (node.type === 'ArrowFunctionExpression' ||
+        node.type === 'FunctionExpression') &&
+      node.body.type === 'BlockStatement'
+    ) {
+      return node.body.body;
+    }
 
-    ast.body.forEach((statement) => {
+    return [];
+  },
+
+  /**
+   * Checks the given statements for possible test info
+   *
+   * @param {RuleContext} context The `context` variable for the source file itself
+   * @param {ASTNode[]} statements The statements to check
+   * @param {Set<ASTNode>} variableIdentifiers
+   * @returns {CallExpression[]}
+   */
+  checkStatementsForTestInfo(
+    context,
+    statements,
+    variableIdentifiers = new Set()
+  ) {
+    const runCalls = [];
+
+    for (const statement of statements) {
       if (statement.type === 'VariableDeclaration') {
         statement.declarations.forEach((declarator) => {
           if (
@@ -404,8 +427,25 @@ module.exports = {
       }
 
       if (
-        statement.type === 'ExpressionStatement' &&
-        statement.expression.type === 'CallExpression' &&
+        statement.type !== 'ExpressionStatement' ||
+        statement.expression.type !== 'CallExpression'
+      ) {
+        continue;
+      }
+
+      for (const arg of statement.expression.arguments) {
+        const extracted = module.exports.extractFunctionBody(arg);
+
+        runCalls.push(
+          ...module.exports.checkStatementsForTestInfo(
+            context,
+            extracted,
+            variableIdentifiers
+          )
+        );
+      }
+
+      if (
         statement.expression.callee.type === 'MemberExpression' &&
         (isRuleTesterConstruction(statement.expression.callee.object) ||
           variableIdentifiers.has(statement.expression.callee.object)) &&
@@ -414,7 +454,22 @@ module.exports = {
       ) {
         runCalls.push(statement.expression);
       }
-    });
+    }
+
+    return runCalls;
+  },
+
+  /**
+   * Performs static analysis on an AST to try to find test cases
+   * @param {RuleContext} context The `context` variable for the source file itself
+   * @param {ASTNode} ast The `Program` node for the file.
+   * @returns {object} An object with `valid` and `invalid` keys containing a list of AST nodes corresponding to tests
+   */
+  getTestInfo(context, ast) {
+    const runCalls = module.exports.checkStatementsForTestInfo(
+      context,
+      ast.body
+    );
 
     return runCalls
       .filter(

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -196,5 +196,34 @@ ruleTester.run('no-identical-tests', rule, {
       `,
       errors: [ERROR_STRING_TEST],
     },
+    {
+      code: `
+        var foo = new RuleTester();
+
+        function testOperator(operator) {
+          foo.run('foo', bar, {
+            valid: [
+              \`$\{operator}\`,
+              \`$\{operator}\`,
+            ],
+            invalid: []
+          });
+        }
+      `,
+      output: `
+        var foo = new RuleTester();
+
+        function testOperator(operator) {
+          foo.run('foo', bar, {
+            valid: [
+              \`$\{operator}\`,
+            ],
+            invalid: []
+          });
+        }
+      `,
+      parserOptions: { ecmaVersion: 2015 },
+      errors: [{ messageId: 'identical', type: 'TemplateLiteral' }],
+    },
   ],
 });

--- a/tests/lib/rules/test-case-property-ordering.js
+++ b/tests/lib/rules/test-case-property-ordering.js
@@ -172,5 +172,35 @@ ruleTester.run('test-case-property-ordering', rule, {
         },
       ],
     },
+    {
+      code: `
+        var tester = new RuleTester();
+
+        describe('my tests', function() {
+          tester.run('foo', bar, {
+            valid: [
+              {\ncode: "foo",\noutput: "",\nerrors: ["baz"],\nparserOptions: "",\n},
+            ]
+          });
+        });
+      `,
+      output: `
+        var tester = new RuleTester();
+
+        describe('my tests', function() {
+          tester.run('foo', bar, {
+            valid: [
+              {\ncode: "foo",\noutput: "",\nparserOptions: "",\nerrors: ["baz"],\n},
+            ]
+          });
+        });
+      `,
+      errors: [
+        {
+          message:
+            'The properties of a test case should be placed in a consistent order: [code, output, parserOptions, errors].',
+        },
+      ],
+    },
   ],
 });

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -672,7 +672,7 @@ describe('utils', () => {
       });
     });
 
-    describe.only('the file has valid tests', () => {
+    describe('the file has valid tests', () => {
       const CASES = {
         'new RuleTester().run(bar, baz, { valid: [foo], invalid: [bar, baz] })':
           { valid: 1, invalid: 2 },
@@ -686,8 +686,26 @@ describe('utils', () => {
           { valid: 0, invalid: 2 },
         [`
           var foo = new bar.RuleTester;
+          describe('my tests', function () {
+            foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })
+          });
+        `]: { valid: 0, invalid: 2 },
+        [`
+          var foo = new bar.RuleTester;
           describe('my tests', () => {
             foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })
+          });
+        `]: { valid: 0, invalid: 2 },
+        [`
+          var foo = new bar.RuleTester;
+          describe('my tests', () => {
+            describe('my tests', () => {
+              describe('my tests', () => {
+                describe('my tests', () => {
+                  foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })
+                });
+              });
+            });
           });
         `]: { valid: 0, invalid: 2 },
         [`
@@ -740,6 +758,19 @@ describe('utils', () => {
         ],
 
         [`
+          describe('one', function() {
+            new RuleTester().run(foo, bar, { valid: [foo], invalid: [] });
+          });
+
+          describe('two', () => {
+            new RuleTester().run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 1, invalid: 0 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
           var foo = new RuleTester;
           var bar = new RuleTester;
           foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
@@ -750,9 +781,37 @@ describe('utils', () => {
         ],
 
         [`
+          var foo = new RuleTester;
+
+          describe('some tests', () => {
+            var bar = new RuleTester;
+            foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
           var foo = new RuleTester, bar = new RuleTester;
           foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
           bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
+          describe('one set of tests', () => {
+            foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+          });
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
         `]: [
           { valid: 3, invalid: 1 },
           { valid: 0, invalid: 2 },

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -713,6 +713,11 @@ describe('utils', () => {
           describe('my tests', () =>
             foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] }));
         `]: { valid: 0, invalid: 2 },
+        [`
+          var foo = new bar.RuleTester();
+          if (eslintVersion >= 8)
+            foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] });
+        `]: { valid: 0, invalid: 2 },
       };
 
       Object.keys(CASES).forEach((testSource) => {
@@ -807,6 +812,40 @@ describe('utils', () => {
 
           describe('one set of tests', () => {
             foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+          });
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
+          if (eslintVersion >= 8) {
+            describe('one set of tests', () => {
+              foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+            });
+          }
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
+          describe('one set of tests', () => {
+            if (eslintVersion >= 8) {
+              foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+            }
           });
 
           describe('another set of tests', () => {

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -855,6 +855,44 @@ describe('utils', () => {
           { valid: 3, invalid: 1 },
           { valid: 0, invalid: 2 },
         ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
+          const testUtilsAgainst = function(value) {
+            foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+          };
+
+          testUtilsAgainst(1);
+          testUtilsAgainst(2);
+          testUtilsAgainst(3);
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
+          const testUtilsAgainst = (value) => {
+            foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+          };
+
+          testUtilsAgainst(1);
+          testUtilsAgainst(2);
+          testUtilsAgainst(3);
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
       };
 
       Object.keys(CASES).forEach((testSource) => {

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -684,6 +684,12 @@ describe('utils', () => {
           { valid: 0, invalid: 2 },
         'var foo = new bar.RuleTester; foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })':
           { valid: 0, invalid: 2 },
+        [`
+          var foo = new bar.RuleTester;
+          describe('my tests', () => {
+            foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })
+          });
+        `]: { valid: 0, invalid: 2 },
       };
 
       Object.keys(CASES).forEach((testSource) => {

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -859,6 +859,25 @@ describe('utils', () => {
         [`
           var foo = new RuleTester, bar = new RuleTester;
 
+          function testUtilsAgainst(value) {
+            foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
+          };
+
+          testUtilsAgainst(1);
+          testUtilsAgainst(2);
+          testUtilsAgainst(3);
+
+          describe('another set of tests', () => {
+            bar.run(foo, bar, { valid: [], invalid: [foo, bar] });
+          });
+        `]: [
+          { valid: 3, invalid: 1 },
+          { valid: 0, invalid: 2 },
+        ],
+
+        [`
+          var foo = new RuleTester, bar = new RuleTester;
+
           const testUtilsAgainst = function(value) {
             foo.run(foo, bar, { valid: [foo, bar, baz], invalid: [foo] });
           };

--- a/tests/lib/utils.js
+++ b/tests/lib/utils.js
@@ -672,7 +672,7 @@ describe('utils', () => {
       });
     });
 
-    describe('the file has valid tests', () => {
+    describe.only('the file has valid tests', () => {
       const CASES = {
         'new RuleTester().run(bar, baz, { valid: [foo], invalid: [bar, baz] })':
           { valid: 1, invalid: 2 },
@@ -689,6 +689,11 @@ describe('utils', () => {
           describe('my tests', () => {
             foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] })
           });
+        `]: { valid: 0, invalid: 2 },
+        [`
+          var foo = new bar.RuleTester();
+          describe('my tests', () =>
+            foo.run(bar, baz, { valid: [,], invalid: [bar, , baz] }));
         `]: { valid: 0, invalid: 2 },
       };
 


### PR DESCRIPTION
I think this should cover most cases though it'd be easier if we were walking the AST tree like ESLint actually does, since really what we're wanting to do is check the body of all `BlockStatement` expressions but without walking we have to manually account for every possible place that could be held.

Still this already I think is a huge improvement - I've tried it on `eslint-plugin-jest` and it caught a few violations (including a couple I'd not noticed myself!)

Resolves #248