### PR TITLE
Update `no-missing-placeholders` and `no-unused-placeholders` to handle messageIds

### DIFF
--- a/lib/rules/no-missing-message-ids.js
+++ b/lib/rules/no-missing-message-ids.js
@@ -71,7 +71,7 @@ module.exports = {
             values.forEach((val) => {
               if (
                 val.type === 'Literal' &&
-                val.value !== null &&
+                typeof val.value === 'string' &&
                 val.value !== '' &&
                 !utils.getMessageIdNodeById(
                   val.value,

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -32,18 +32,16 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     let contextIdentifiers;
 
-    // ----------------------------------------------------------------------
-    // Public
-    // ----------------------------------------------------------------------
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(
-          sourceCode.scopeManager,
-          ast
-        );
+        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
         if (
@@ -57,38 +55,30 @@ module.exports = {
             return;
           }
 
-          const info = utils.getRuleInfo(sourceCode);
-          const metaNode = info.meta;
-          const messagesNode =
-            metaNode &&
-            metaNode.properties &&
-            metaNode.properties.find(
-              (p) => p.type === 'Property' && utils.getKeyName(p) === 'messages'
-            );
-
           const reportMessagesAndDataArray =
             utils.collectReportViolationAndSuggestionData(reportInfo);
 
-          // Check for any potential instances where we can use the messageId to fill in the message for convenience.
-          reportMessagesAndDataArray.forEach((obj) => {
-            if (
-              !obj.message &&
-              obj.messageId &&
-              obj.messageId.type === 'Literal'
-            ) {
-              const correspondingMessage =
-                messagesNode &&
-                messagesNode.value.properties &&
-                messagesNode.value.properties.find(
-                  (p) =>
-                    p.type === 'Property' &&
-                    utils.getKeyName(p) === obj.messageId.value
+          if (messagesNode) {
+            // Check for any potential instances where we can use the messageId to fill in the message for convenience.
+            reportMessagesAndDataArray.forEach((obj) => {
+              if (
+                !obj.message &&
+                obj.messageId &&
+                obj.messageId.type === 'Literal' &&
+                typeof obj.messageId.value === 'string'
+              ) {
+                const correspondingMessage = utils.getMessageIdNodeById(
+                  obj.messageId.value,
+                  ruleInfo,
+                  scopeManager,
+                  context.getScope()
                 );
-              if (correspondingMessage) {
-                obj.message = correspondingMessage.value;
+                if (correspondingMessage) {
+                  obj.message = correspondingMessage.value;
+                }
               }
-            }
-          });
+            });
+          }
 
           for (const { message, data } of reportMessagesAndDataArray.filter(
             (obj) => obj.message

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -31,6 +31,7 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
     let contextIdentifiers;
 
     // ----------------------------------------------------------------------
@@ -39,7 +40,6 @@ module.exports = {
 
     return {
       Program(ast) {
-        const sourceCode = context.getSourceCode();
         contextIdentifiers = utils.getContextIdentifiers(
           sourceCode.scopeManager,
           ast
@@ -57,10 +57,42 @@ module.exports = {
             return;
           }
 
-          const reportMessagesAndDataArray = utils
-            .collectReportViolationAndSuggestionData(reportInfo)
-            .filter((obj) => obj.message);
-          for (const { message, data } of reportMessagesAndDataArray) {
+          const info = utils.getRuleInfo(sourceCode);
+          const metaNode = info.meta;
+          const messagesNode =
+            metaNode &&
+            metaNode.properties &&
+            metaNode.properties.find(
+              (p) => p.type === 'Property' && utils.getKeyName(p) === 'messages'
+            );
+
+          const reportMessagesAndDataArray =
+            utils.collectReportViolationAndSuggestionData(reportInfo);
+
+          // Check for any potential instances where we can use the messageId to fill in the message for convenience.
+          reportMessagesAndDataArray.forEach((obj) => {
+            if (
+              !obj.message &&
+              obj.messageId &&
+              obj.messageId.type === 'Literal'
+            ) {
+              const correspondingMessage =
+                messagesNode &&
+                messagesNode.value.properties &&
+                messagesNode.value.properties.find(
+                  (p) =>
+                    p.type === 'Property' &&
+                    utils.getKeyName(p) === obj.messageId.value
+                );
+              if (correspondingMessage) {
+                obj.message = correspondingMessage.value;
+              }
+            }
+          });
+
+          for (const { message, data } of reportMessagesAndDataArray.filter(
+            (obj) => obj.message
+          )) {
             const messageStaticValue = getStaticValue(
               message,
               context.getScope()

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -30,6 +30,7 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
     let contextIdentifiers;
 
     // ----------------------------------------------------------------------
@@ -38,7 +39,6 @@ module.exports = {
 
     return {
       Program(ast) {
-        const sourceCode = context.getSourceCode();
         contextIdentifiers = utils.getContextIdentifiers(
           sourceCode.scopeManager,
           ast
@@ -56,10 +56,42 @@ module.exports = {
             return;
           }
 
-          const reportMessagesAndDataArray = utils
-            .collectReportViolationAndSuggestionData(reportInfo)
-            .filter((obj) => obj.message);
-          for (const { message, data } of reportMessagesAndDataArray) {
+          const info = utils.getRuleInfo(sourceCode);
+          const metaNode = info.meta;
+          const messagesNode =
+            metaNode &&
+            metaNode.properties &&
+            metaNode.properties.find(
+              (p) => p.type === 'Property' && utils.getKeyName(p) === 'messages'
+            );
+
+          const reportMessagesAndDataArray =
+            utils.collectReportViolationAndSuggestionData(reportInfo);
+
+          // Check for any potential instances where we can use the messageId to fill in the message for convenience.
+          reportMessagesAndDataArray.forEach((obj) => {
+            if (
+              !obj.message &&
+              obj.messageId &&
+              obj.messageId.type === 'Literal'
+            ) {
+              const correspondingMessage =
+                messagesNode &&
+                messagesNode.value.properties &&
+                messagesNode.value.properties.find(
+                  (p) =>
+                    p.type === 'Property' &&
+                    utils.getKeyName(p) === obj.messageId.value
+                );
+              if (correspondingMessage) {
+                obj.message = correspondingMessage.value;
+              }
+            }
+          });
+
+          for (const { message, data } of reportMessagesAndDataArray.filter(
+            (obj) => obj.message
+          )) {
             const messageStaticValue = getStaticValue(
               message,
               context.getScope()

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -31,18 +31,16 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    const { scopeManager } = sourceCode;
+
     let contextIdentifiers;
 
-    // ----------------------------------------------------------------------
-    // Public
-    // ----------------------------------------------------------------------
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
 
     return {
       Program(ast) {
-        contextIdentifiers = utils.getContextIdentifiers(
-          sourceCode.scopeManager,
-          ast
-        );
+        contextIdentifiers = utils.getContextIdentifiers(scopeManager, ast);
       },
       CallExpression(node) {
         if (
@@ -56,38 +54,30 @@ module.exports = {
             return;
           }
 
-          const info = utils.getRuleInfo(sourceCode);
-          const metaNode = info.meta;
-          const messagesNode =
-            metaNode &&
-            metaNode.properties &&
-            metaNode.properties.find(
-              (p) => p.type === 'Property' && utils.getKeyName(p) === 'messages'
-            );
-
           const reportMessagesAndDataArray =
             utils.collectReportViolationAndSuggestionData(reportInfo);
 
-          // Check for any potential instances where we can use the messageId to fill in the message for convenience.
-          reportMessagesAndDataArray.forEach((obj) => {
-            if (
-              !obj.message &&
-              obj.messageId &&
-              obj.messageId.type === 'Literal'
-            ) {
-              const correspondingMessage =
-                messagesNode &&
-                messagesNode.value.properties &&
-                messagesNode.value.properties.find(
-                  (p) =>
-                    p.type === 'Property' &&
-                    utils.getKeyName(p) === obj.messageId.value
+          if (messagesNode) {
+            // Check for any potential instances where we can use the messageId to fill in the message for convenience.
+            reportMessagesAndDataArray.forEach((obj) => {
+              if (
+                !obj.message &&
+                obj.messageId &&
+                obj.messageId.type === 'Literal' &&
+                typeof obj.messageId.value === 'string'
+              ) {
+                const correspondingMessage = utils.getMessageIdNodeById(
+                  obj.messageId.value,
+                  ruleInfo,
+                  scopeManager,
+                  context.getScope()
                 );
-              if (correspondingMessage) {
-                obj.message = correspondingMessage.value;
+                if (correspondingMessage) {
+                  obj.message = correspondingMessage.value;
+                }
               }
-            }
-          });
+            });
+          }
 
           for (const { message, data } of reportMessagesAndDataArray.filter(
             (obj) => obj.message

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -124,7 +124,7 @@ ruleTester.run('no-missing-placeholders', rule, {
         }
       };
     `,
-    // messageId but the message property doesn't exist yet.
+    // messageId but the message doesn't exist in `meta.messages`.
     `
       module.exports = {
         meta: {
@@ -135,10 +135,18 @@ ruleTester.run('no-missing-placeholders', rule, {
         }
       };
     `,
-    // messageId but no messages object doesn't exist yet.
+    // messageId but no `meta.messages`.
     `
       module.exports = {
         meta: { },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId but no `meta`.
+    `
+      module.exports = {
         create(context) {
           context.report({ node, messageId: 'myMessageId' });
         }

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -113,6 +113,52 @@ ruleTester.run('no-missing-placeholders', rule, {
         }
       };
     `,
+    // messageId but no placeholder.
+    `
+      module.exports = {
+        meta: {
+          messages: { myMessageId: 'foo' }
+        },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId but the message property doesn't exist yet.
+    `
+      module.exports = {
+        meta: {
+          messages: { }
+        },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId but no messages object doesn't exist yet.
+    `
+      module.exports = {
+        meta: { },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId with correctly-used placeholder.
+    `
+      module.exports = {
+        meta: {
+          messages: { myMessageId: 'foo {{bar}}' }
+        },
+        create(context) {
+          context.report({
+            node,
+            messageId: 'myMessageId',
+            data: { bar: 'baz' }
+          });
+        }
+      };
+    `,
     // Message in variable.
     `
       const MESSAGE = 'foo {{bar}}';
@@ -136,6 +182,25 @@ ruleTester.run('no-missing-placeholders', rule, {
             suggest: [
               {
                 desc: 'Remove {{functionName}}',
+                data: {
+                  functionName: 'foo'
+                }
+              }
+            ]
+          });
+        }
+      };
+    `,
+    // Suggestion with messageId
+    `
+      module.exports = {
+        meta: { messages: { myMessageId: 'Remove {{functionName}}' } },
+        create(context) {
+          context.report({
+            node,
+            suggest: [
+              {
+                messageId: 'myMessageId',
                 data: {
                   functionName: 'foo'
                 }
@@ -270,6 +335,25 @@ ruleTester.run('no-missing-placeholders', rule, {
       errors: [error('bar')],
     },
     {
+      // Suggestion and messageId
+      code: `
+        module.exports = {
+          meta: { messages: { myMessageId: 'foo {{bar}}' } },
+          create(context) {
+            context.report({
+              node,
+              suggest: [
+                {
+                  messageId: 'myMessageId',
+                }
+              ]
+            });
+          }
+        };
+      `,
+      errors: [error('bar')],
+    },
+    {
       // `create` in variable.
       code: `
         function create(context) {
@@ -282,6 +366,21 @@ ruleTester.run('no-missing-placeholders', rule, {
         module.exports = { create };
       `,
       errors: [error('hasOwnProperty')],
+    },
+    {
+      // messageId.
+      code: `
+        module.exports = {
+          meta: { messages: { myMessageId: 'foo {{bar}}' } },
+          create(context) {
+            context.report({
+              node,
+              messageId: 'myMessageId'
+            });
+          }
+        };
+      `,
+      errors: [error('bar')],
     },
   ],
 });

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -122,6 +122,60 @@ ruleTester.run('no-unused-placeholders', rule, {
         }
       };
     `,
+    // Suggestion with messageId
+    `
+      module.exports = {
+        meta: { messages: { myMessageId: 'foo {{bar}}' } },
+        create(context) {
+          context.report({
+            node,
+            suggest: [
+              {
+                messageId: 'myMessageId',
+                data: { 'bar': 'baz' }
+              }
+            ]
+          });
+        }
+      };
+    `,
+    // messageId but no placeholder.
+    `
+      module.exports = {
+        meta: {
+          messages: { myMessageId: 'foo' }
+        },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId but the message property doesn't exist yet.
+    `
+      module.exports = {
+        meta: {
+          messages: { }
+        },
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId with correctly-used placeholder.
+    `
+      module.exports = {
+        meta: {
+          messages: { myMessageId: 'foo {{bar}}' }
+        },
+        create(context) {
+          context.report({
+            node,
+            messageId: 'myMessageId',
+            data: { bar: 'baz' }
+          });
+        }
+      };
+    `,
   ],
 
   invalid: [
@@ -198,6 +252,22 @@ ruleTester.run('no-unused-placeholders', rule, {
       errors: [error('baz')],
     },
     {
+      // messageId.
+      code: `
+        module.exports = {
+          meta: { messages: { myMessageId: 'foo' } },
+          create(context) {
+            context.report({
+              node,
+              messageId: 'myMessageId',
+              data: { bar }
+            });
+          }
+        };
+      `,
+      errors: [error('bar')],
+    },
+    {
       // Suggestion
       code: `
         module.exports = {
@@ -207,6 +277,26 @@ ruleTester.run('no-unused-placeholders', rule, {
               suggest: [
                 {
                   desc: 'foo',
+                  data: { bar }
+                }
+              ]
+            });
+          }
+        };
+      `,
+      errors: [error('bar')],
+    },
+    {
+      // Suggestion and messageId
+      code: `
+        module.exports = {
+          meta: { messages: { myMessageId: 'foo' } },
+          create(context) {
+            context.report({
+              node,
+              suggest: [
+                {
+                  messageId: 'myMessageId',
                   data: { bar }
                 }
               ]

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -161,6 +161,23 @@ ruleTester.run('no-unused-placeholders', rule, {
         }
       };
     `,
+    // messageId but no `meta.messages`.
+    `
+      module.exports = {
+        meta: {},
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
+    // messageId but no `meta`.
+    `
+      module.exports = {
+        create(context) {
+          context.report({ node, messageId: 'myMessageId' });
+        }
+      };
+    `,
     // messageId with correctly-used placeholder.
     `
       module.exports = {


### PR DESCRIPTION
Fixes the second part of #57.

Correct placeholder with messageId example: 
```js
module.exports = {
    meta: {
        messages: { myMessageId: 'foo {{bar}}' } 
    },
    create(context) {
        context.report({
            node,
            messageId: 'myMessageId',
            data: { bar: 'baz' }
        });
    }
};
```

- [x] Implement this
- [x] Ensure it applies to suggestions too
- [x] Refactor/DRY
   - [x] Reuse util functions from https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/254

Part of the V5 release (#230).