### PR TITLE
breaking: drop ESLint v6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,17 +37,6 @@ jobs:
       - run: npm install
       - run: npm run lint
 
-  eslint6:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: "16.x"
-    - run: npm install
-    - run: npm install --save-dev eslint@6
-    - run: npm test
-      
   eslint7:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.0"
+    "eslint": ">=7.0.0"
   },
   "engines": {
     "node": "^12.22.0 || ^14.17.0 || >=16.0.0"


### PR DESCRIPTION
ESLint v6 was released in [2019](https://eslint.org/blog/2019/06/eslint-v6.0.0-released/). Supporting the last two versions, ESLint v7 and ESLint v8, should be sufficient. ESLint v9 will also be released later this year.

Part of v5 release (https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/230).
