### PR TITLE
breaking: strictly define Node API

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.4.0",
   "description": "An ESLint plugin for linting ESLint plugins",
   "author": "Teddy Katz",
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js",
   "license": "MIT",
   "scripts": {
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",


### PR DESCRIPTION
* Add `"exports": "./lib/index.js"` to package.json to strictly define NodeJS API (ESLint itself made the [same change](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#the-lib-entrypoint-has-been-removed))

Part of v5 release (https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/230).
