### PR TITLE
chore: run version-specific CI jobs on Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "18.x"
       - run: npm install
       - run: npm run lint
 
@@ -43,18 +43,18 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: "16.x"
+        node-version: "18.x"
     - run: npm install
     - run: npm install --save-dev eslint@6
     - run: npm test
-      
+
   eslint7:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: "16.x"
+        node-version: "18.x"
     - run: npm install
     - run: npm install --save-dev eslint@7
     - run: npm test


### PR DESCRIPTION
This is the latest Node version so we can default to this on some of the version-specific jobs.