### PR TITLE
chore: add npm-package-json-lint

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,0 +1,15 @@
+{
+  "rules": {
+    "no-duplicate-properties": "error",
+    "no-repeated-dependencies": "error",
+    "prefer-alphabetical-bundledDependencies": "error",
+    "prefer-alphabetical-dependencies": "error",
+    "prefer-alphabetical-devDependencies": "error",
+    "prefer-alphabetical-optionalDependencies": "error",
+    "prefer-alphabetical-scripts": "error",
+    "prefer-caret-version-dependencies": "error",
+    "prefer-caret-version-devDependencies": ["error", {
+      "exceptions": ["eslint-plugin-eslint-plugin"]
+    }]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
+    "generate-readme-table": "node build/generate-readme-table.js",
     "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
     "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint --cache .",
-    "generate-readme-table": "node build/generate-readme-table.js",
+    "lint:package-json": "npmPkgJsonLint .",
     "release": "release-it",
     "test": "nyc --all --check-coverage --include lib mocha tests --recursive"
   },
@@ -60,6 +61,7 @@
     "lodash": "^4.17.2",
     "markdownlint-cli": "^0.30.0",
     "mocha": "^9.1.4",
+    "npm-package-json-lint": "^6.3.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",


### PR DESCRIPTION
Some basic checks for mistakes in package.json. I use this in many other repos.

I fixed a violation about our scripts not being sorted alphabetically.

https://www.npmjs.com/package/npm-package-json-lint