### PR TITLE
docs: modernize rule doc for `prefer-object-rule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Name | ✔️ | 🛠 | 💡 | Description
 [no-unused-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-unused-placeholders.md) | ✔️ |  |  | disallow unused placeholders in rule report messages
 [no-useless-token-range](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-useless-token-range.md) | ✔️ | 🛠 |  | disallow unnecessary calls to `sourceCode.getFirstToken()` and `sourceCode.getLastToken()`
 [prefer-message-ids](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-message-ids.md) |  |  |  | require using `messageId` instead of `message` to report rule violations
-[prefer-object-rule](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-object-rule.md) | ✔️ | 🛠 |  | disallow rule exports where the export is a function
+[prefer-object-rule](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-object-rule.md) | ✔️ | 🛠 |  | disallow function-style rules
 [prefer-output-null](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-output-null.md) |  | 🛠 |  | disallow invalid RuleTester test cases where the `output` matches the `code`
 [prefer-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-placeholders.md) |  |  |  | require using placeholders for dynamic report messages
 [prefer-replace-text](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-replace-text.md) |  |  |  | require using `replaceText()` instead of `replaceTextRange()`

--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -1,35 +1,23 @@
-# Disallow rule exports where the export is a function (prefer-object-rule)
+# Disallow function-style rules (prefer-object-rule)
 
 ✔️ The `"extends": "plugin:eslint-plugin/recommended"` property in a configuration file enables this rule.
 
 ⚒️ The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#--fix) can automatically fix some of the problems reported by this rule.
 
+Prior to ESLint v9, ESLint supported both [function-style](https://eslint.org/docs/developer-guide/working-with-rules-deprecated) and [object-style](https://eslint.org/docs/developer-guide/working-with-rules) rules. However, function-style rules have been deprecated since 2016, and do not support newer features like autofixing and suggestions.
+
+As of [ESLint v9](https://github.com/eslint/rfcs/tree/main/designs/2021-schema-object-rules#motivation-for-requiring-object-style-rules), ESLint supports only object-style rules.
+
 ## Rule Details
 
-The rule reports an error if it encounters a rule that's defined using the [deprecated style](https://eslint.org/docs/developer-guide/working-with-rules-deprecated) of just a `create` function instead of the newer [object style](https://eslint.org/docs/developer-guide/working-with-rules).
+The rule reports an error if it encounters a rule that's defined using the deprecated function-style format.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eslint-plugin/prefer-object-rule: error */
 
-module.exports = function (context) {
-  return {
-    Program() {
-      context.report();
-    },
-  };
-};
-
 module.exports = function create(context) {
-  return {
-    Program() {
-      context.report();
-    },
-  };
-};
-
-module.exports = (context) => {
   return {
     Program() {
       context.report();
@@ -44,27 +32,8 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/prefer-object-rule: error */
 
 module.exports = {
+  meta: { /* ... */ },
   create(context) {
-    return {
-      Program() {
-        context.report();
-      },
-    };
-  },
-};
-
-module.exports = {
-  create(context) {
-    return {
-      Program() {
-        context.report();
-      },
-    };
-  },
-};
-
-module.exports = {
-  create: (context) => {
     return {
       Program() {
         context.report();

--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -15,7 +15,7 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'disallow rule exports where the export is a function',
+      description: 'disallow function-style rules',
       category: 'Rules',
       recommended: true,
       url: 'https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/tree/HEAD/docs/rules/prefer-object-rule.md',


### PR DESCRIPTION
* Improve/simplify wording
* Add context including link to approved RFC with latest plans for ESLint v9
* Remove redundant examples from rule doc