### PR TITLE
docs: modernize rule doc for `no-identical-tests`

### DIFF
--- a/docs/rules/no-identical-tests.md
+++ b/docs/rules/no-identical-tests.md
@@ -4,9 +4,13 @@
 
 ⚒️ The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#--fix) can automatically fix some of the problems reported by this rule.
 
-When a rule has a lot of tests, it's sometimes difficult to tell if any tests are duplicates. This rule would warn if any test cases have the same properties.
+Duplicate test cases can cause confusion, can be hard to detect manually in a long file, and serve no purpose.
+
+As of [ESLint v9](https://github.com/eslint/rfcs/tree/main/designs/2021-stricter-rule-test-validation#disallow-identical-test-cases), ESLint attempts to detect and disallow duplicate tests.
 
 ## Rule Details
+
+This rule detects duplicate test cases.
 
 Examples of **incorrect** code for this rule:
 
@@ -14,8 +18,20 @@ Examples of **incorrect** code for this rule:
 /* eslint eslint-plugin/no-identical-tests: error */
 
 new RuleTester().run('foo', bar, {
-  valid: [{ code: 'foo' }, { code: 'foo' }],
-  invalid: [],
+  valid: [
+    'foo',
+    'foo', // duplicate of previous
+  ],
+  invalid: [
+    {
+      code: 'bar',
+      errors: [{ messageId: 'my-message', type: 'CallExpression' }],
+    },
+    {
+      code: 'bar',
+      errors: [{ messageId: 'my-message', type: 'CallExpression' }],
+    }, // duplicate of previous
+  ],
 });
 ```
 
@@ -25,11 +41,12 @@ Examples of **correct** code for this rule:
 /* eslint eslint-plugin/no-identical-tests: error */
 
 new RuleTester().run('foo', bar, {
-  valid: [{ code: 'foo' }, { code: 'bar' }],
-  invalid: [],
+  valid: ['foo', 'bar'],
+  invalid: [
+    {
+      code: 'baz',
+      errors: [{ messageId: 'my-message', type: 'CallExpression' }],
+    },
+  ],
 });
 ```
-
-## When Not To Use It
-
-If you want to allow identical tests, do not enable this rule.


### PR DESCRIPTION
* Improve explanation
* Improve examples
* Include latest information from approved RFC for ESLint v9
* Remove non-sensical `When Not To Use It` section