### PR TITLE
docs: add missing items in v5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@
 
 ### ⚠ BREAKING CHANGES
 
-* Update `no-missing-placeholders` and `no-unused-placeholders` to handle messageIds (#252)
+* drop Node 12/17 support ([#256](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/256))
+* drop ESLint v6 support ([#257](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/257))
+* strictly define Node API ([#259](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/259))
+* add `recommended` rules `prefer-message-ids`, `prefer-output-null`, `no-missing-message-id
+s`, `no-unused-message-ids` ([#258](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/258))
+* Update `no-missing-placeholders` and `no-unused-placeholders` to handle messageIds ([#252](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/252))
 
 ### Features
 


### PR DESCRIPTION
they were missing as "breaking:" is not a valid tag in conventional commits.
the commit just added them manually.