### PR TITLE
Allow additional types of dynamic schemas in `require-meta-schema` rule

### DIFF
--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -104,7 +104,10 @@ module.exports = {
           hasEmptySchema = true;
         }
 
-        if (!['ArrayExpression', 'ObjectExpression'].includes(value.type)) {
+        if (
+          value.type === 'Literal' ||
+          (value.type === 'Identifier' && value.name === 'undefined')
+        ) {
           context.report({ node: value, messageId: 'wrongType' });
         }
       },

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -63,6 +63,7 @@ ruleTester.run('require-meta-schema', rule, {
       `,
       parserOptions: { sourceType: 'module' },
     },
+    // Variable schema with array value.
     `
       const schema = [];
       module.exports = {
@@ -70,10 +71,46 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) {}
       };
     `,
+    // Variable schema with object value.
     `
       const foo = {};
       module.exports = {
         meta: { schema: foo },
+        create(context) {}
+      };
+    `,
+    // Variable schema with no static value.
+    `
+      module.exports = {
+        meta: { schema },
+        create(context) {}
+      };
+    `,
+    // Variable schema pointing to unknown variable chain.
+    `
+      module.exports = {
+        meta: { schema: baseRule.meta.schema },
+        create(context) {}
+      };
+    `,
+    // Schema with function call as value.
+    `
+      module.exports = {
+        meta: { schema: getSchema() },
+        create(context) {}
+      };
+    `,
+    // Schema with ternary (conditional) expression.
+    `
+      module.exports = {
+        meta: { schema: foo ? [] : {} },
+        create(context) {}
+      };
+    `,
+    // Schema with logical expression.
+    `
+      module.exports = {
+        meta: { schema: foo || {} },
         create(context) {}
       };
     `,
@@ -295,6 +332,28 @@ schema: [] },
       `,
       output: null,
       errors: [{ messageId: 'wrongType', type: 'Identifier', suggestions: [] }],
+    },
+    {
+      // Schema with number literal value.
+      code: `
+        module.exports = {
+          meta: { schema: 123 },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ messageId: 'wrongType', type: 'Literal', suggestions: [] }],
+    },
+    {
+      // Schema with string literal value.
+      code: `
+        module.exports = {
+          meta: { schema: 'hello world' },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [{ messageId: 'wrongType', type: 'Literal', suggestions: [] }],
     },
     {
       code: `


### PR DESCRIPTION
The goal is to ban obviously-invalid types like `Literal` (string/number) for `meta.schema`, while allowing any kind of variables/function calls/dynamic calculation of the schema.

Previously, a simple variable was allowed, but now these are also allowed:

```js
{
  schema: baseRule.meta.schema
}
```

```js
{
  schema: getSchema()
}
```


Fixes #273.