### PR TITLE
Clarify violation messages for `no-missing-placeholders` and `no-unused-placeholders`

### DIFF
--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -26,7 +26,7 @@ module.exports = {
     schema: [],
     messages: {
       placeholderDoesNotExist:
-        'The placeholder {{{{missingKey}}}} does not exist.',
+        "The placeholder {{{{missingKey}}}} is missing (must provide it in the report's `data` object).",
     },
   },
 

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -25,7 +25,8 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {
-      placeholderUnused: 'The placeholder {{{{unusedKey}}}} is unused.',
+      placeholderUnused:
+        'The placeholder {{{{unusedKey}}}} is unused (does not exist in the actual message).',
     },
   },
 

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -18,7 +18,10 @@ const RuleTester = require('eslint').RuleTester;
  * @returns {object} An expected error
  */
 function error(missingKey, type = 'Literal') {
-  return { type, message: `The placeholder {{${missingKey}}} does not exist.` };
+  return {
+    type,
+    message: `The placeholder {{${missingKey}}} is missing (must provide it in the report's \`data\` object).`,
+  };
 }
 
 // ------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -18,7 +18,10 @@ const RuleTester = require('eslint').RuleTester;
  * @returns {object} An expected error
  */
 function error(unusedKey, type = 'Literal') {
-  return { type, message: `The placeholder {{${unusedKey}}} is unused.` };
+  return {
+    type,
+    message: `The placeholder {{${unusedKey}}} is unused (does not exist in the actual message).`,
+  };
 }
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
While investigating #276, I noticed that the existing violation messages were particularly confusing. The messages "the placeholder is missing" or "the placeholder does not exist" are very ambiguous about what they mean.