### PR TITLE
Improve violation reporting location for `no-unused-placeholders`

### DIFF
--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -107,7 +107,7 @@ module.exports = {
                 const key = utils.getKeyName(prop);
                 if (!placeholdersInMessage.has(key)) {
                   context.report({
-                    node: message,
+                    node: prop,
                     messageId: 'placeholderUnused',
                     data: { unusedKey: key },
                   });

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -236,7 +236,19 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar', 'Literal')],
+      errors: [
+        error(
+          'bar',
+          'Literal',
+          // report on `message`
+          {
+            line: 6,
+            endLine: 6,
+            column: 24,
+            endColumn: 37,
+          }
+        ),
+      ],
     },
     {
       code: `

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -17,8 +17,12 @@ const RuleTester = require('eslint').RuleTester;
  * @param {string} unusedKey The placeholder that is unused
  * @returns {object} An expected error
  */
-function error(unusedKey, type = 'Literal') {
-  return { type, message: `The placeholder {{${unusedKey}}} is unused.` };
+function error(unusedKey, extra) {
+  return {
+    type: 'Property', // The property in the report's `data` object for the unused placeholder.
+    message: `The placeholder {{${unusedKey}}} is unused.`,
+    ...extra,
+  };
 }
 
 // ------------------------------------------------------------------------------
@@ -208,7 +212,18 @@ ruleTester.run('no-unused-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [
+        error(
+          'bar',
+          // report on property in data object
+          {
+            line: 7,
+            endLine: 7,
+            column: 23,
+            endColumn: 26,
+          }
+        ),
+      ],
     },
     {
       // With `create` as variable.
@@ -238,7 +253,7 @@ ruleTester.run('no-unused-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar', 'Identifier')],
+      errors: [error('bar')],
     },
     {
       code: `


### PR DESCRIPTION
Fixes #276 (half of it).

Situation 1:

```js
module.exports = {
  create(context) {
    context.report({
      node,
      message: 'hello world', // violation should not be reported here
      data: {
        bar: 'abc' // violation should be reported here on the unused placeholder property
      }
    });
  },
};
```

Situation 2 (even worse because the violation is not even reported inside the specific context.report() call):

```js
module.exports = {
  meta: {
    messages: {
      foo: 'hello world', // violation should not be reported here
    }
  },
  create(context) {
    context.report({
      node,
      messageId: 'foo',
      data: {
        bar: 'abc' // violation should be reported here on the unused placeholder property
      }
    });
  },
};
```