### PR TITLE
Improve violation reporting location in `no-missing-placeholders`

### DIFF
--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -80,9 +80,11 @@ module.exports = {
             });
           }
 
-          for (const { message, data } of reportMessagesAndDataArray.filter(
-            (obj) => obj.message
-          )) {
+          for (const {
+            message,
+            messageId,
+            data,
+          } of reportMessagesAndDataArray.filter((obj) => obj.message)) {
             const messageStaticValue = getStaticValue(
               message,
               context.getScope()
@@ -112,7 +114,7 @@ module.exports = {
 
                 if (!matchingProperty) {
                   context.report({
-                    node: message,
+                    node: data || messageId || message,
                     messageId: 'placeholderDoesNotExist',
                     data: { missingKey: match[1] },
                   });

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -17,8 +17,12 @@ const RuleTester = require('eslint').RuleTester;
  * @param {string} missingKey The placeholder that is missing
  * @returns {object} An expected error
  */
-function error(missingKey, type = 'Literal') {
-  return { type, message: `The placeholder {{${missingKey}}} does not exist.` };
+function error(missingKey, type, extra) {
+  return {
+    type,
+    message: `The placeholder {{${missingKey}}} does not exist.`,
+    ...extra,
+  };
 }
 
 // ------------------------------------------------------------------------------
@@ -232,7 +236,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'Literal')],
     },
     {
       code: `
@@ -246,7 +250,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'ObjectExpression')],
     },
     {
       code: `
@@ -260,7 +264,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('hasOwnProperty')],
+      errors: [error('hasOwnProperty', 'ObjectExpression')],
     },
     {
       code: `
@@ -268,7 +272,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           context.report(node, 'foo {{bar}}', { baz: 'qux' }); return {};
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'ObjectExpression')],
     },
     {
       // Message in variable.
@@ -278,7 +282,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           context.report(node, MESSAGE, { baz: 'qux' }); return {};
         };
       `,
-      errors: [error('bar', 'Identifier')],
+      errors: [error('bar', 'ObjectExpression')],
     },
     {
       code: `
@@ -286,7 +290,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           context.report(node, { line: 1, column: 3 }, 'foo {{bar}}', { baz: 'baz' }); return {};
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'ObjectExpression')],
     },
     {
       code: `
@@ -300,7 +304,19 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [
+        error(
+          'bar',
+          'ObjectExpression',
+          // report on data
+          {
+            line: 7,
+            endLine: 7,
+            column: 21,
+            endColumn: 39,
+          }
+        ),
+      ],
     },
 
     {
@@ -340,7 +356,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'ObjectExpression')],
     },
     {
       // Suggestion and messageId
@@ -359,7 +375,7 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [error('bar', 'Literal')],
     },
     {
       // `create` in variable.
@@ -373,7 +389,7 @@ ruleTester.run('no-missing-placeholders', rule, {
         }
         module.exports = { create };
       `,
-      errors: [error('hasOwnProperty')],
+      errors: [error('hasOwnProperty', 'ObjectExpression')],
     },
     {
       // messageId.
@@ -388,7 +404,19 @@ ruleTester.run('no-missing-placeholders', rule, {
           }
         };
       `,
-      errors: [error('bar')],
+      errors: [
+        error(
+          'bar',
+          'Literal',
+          // report on the messageId
+          {
+            line: 7,
+            endLine: 7,
+            column: 26,
+            endColumn: 39,
+          }
+        ),
+      ],
     },
   ],
 });


### PR DESCRIPTION
Fixes https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/276 (half of it).

Previously, the violation might not even be reported inside the specific context.report() call that it was for.

Now, we report on the data object when it exists.

```js
module.exports = {
  meta: {
    messages: {
      foo: 'hello world', // violation should not be reported here
    }
  },
  create(context) {
    context.report({
      node,
      messageId: 'foo', 
      data: { // violation should be reported here
        bar: 'abc' 
      }
    });
  },
};
```