### PR TITLE
Fix false positive with `no-unused-message-ids` from external violation reporting function

### DIFF
--- a/lib/rules/no-unused-message-ids.js
+++ b/lib/rules/no-unused-message-ids.js
@@ -30,7 +30,8 @@ module.exports = {
 
     const messageIdsUsed = new Set();
     let contextIdentifiers;
-    let shouldPerformUnusedCheck = true;
+    let hasSeenUnknownMessageId = false;
+    let hasSeenViolationReport = false;
 
     const messageIdNodes = utils.getMessageIdNodes(info, scopeManager);
     if (!messageIdNodes) {
@@ -44,22 +45,29 @@ module.exports = {
       },
 
       'Program:exit'() {
-        if (shouldPerformUnusedCheck) {
-          const messageIdNodesUnused = messageIdNodes.filter(
-            (node) =>
-              !messageIdsUsed.has(utils.getKeyName(node, context.getScope()))
-          );
+        if (hasSeenUnknownMessageId || !hasSeenViolationReport) {
+          /*
+          Bail out when the rule is likely to have false positives.
+          - If we saw a dynamic/unknown messageId
+          - If we couldn't find any violation reporting code, likely because a helper function from an external file is handling this
+          */
+          return;
+        }
 
-          // Report any messageIds that were never used.
-          for (const messageIdNode of messageIdNodesUnused) {
-            context.report({
-              node: messageIdNode,
-              messageId: 'unusedMessage',
-              data: {
-                messageId: utils.getKeyName(messageIdNode, context.getScope()),
-              },
-            });
-          }
+        const messageIdNodesUnused = messageIdNodes.filter(
+          (node) =>
+            !messageIdsUsed.has(utils.getKeyName(node, context.getScope()))
+        );
+
+        // Report any messageIds that were never used.
+        for (const messageIdNode of messageIdNodesUnused) {
+          context.report({
+            node: messageIdNode,
+            messageId: 'unusedMessage',
+            data: {
+              messageId: utils.getKeyName(messageIdNode, context.getScope()),
+            },
+          });
         }
       },
 
@@ -76,6 +84,8 @@ module.exports = {
             return;
           }
 
+          hasSeenViolationReport = true;
+
           const reportMessagesAndDataArray =
             utils.collectReportViolationAndSuggestionData(reportInfo);
           for (const { messageId } of reportMessagesAndDataArray.filter(
@@ -90,7 +100,7 @@ module.exports = {
               values.some((val) => val.type !== 'Literal')
             ) {
               // When a dynamic messageId is used and we can't detect its value, disable the rule to avoid false positives.
-              shouldPerformUnusedCheck = false;
+              hasSeenUnknownMessageId = true;
             }
             values.forEach((val) => messageIdsUsed.add(val.value));
           }
@@ -101,17 +111,21 @@ module.exports = {
         // In order to reduce false positives, we will also check for messageId properties anywhere in the file.
         // This is helpful especially in the event that helper functions are used for reporting violations.
         if (node.key.type === 'Identifier' && node.key.name === 'messageId') {
+          hasSeenViolationReport = true;
+
           const values =
             node.value.type === 'Literal'
               ? [node.value]
               : utils.findPossibleVariableValues(node.value, scopeManager);
+
           if (
             values.length === 0 ||
             values.some((val) => val.type !== 'Literal')
           ) {
             // When a dynamic messageId is used and we can't detect its value, disable the rule to avoid false positives.
-            shouldPerformUnusedCheck = false;
+            hasSeenUnknownMessageId = true;
           }
+
           values.forEach((val) => messageIdsUsed.add(val.value));
         }
       },

--- a/tests/lib/rules/no-unused-message-ids.js
+++ b/tests/lib/rules/no-unused-message-ids.js
@@ -220,6 +220,13 @@ ruleTester.run('no-unused-message-ids', rule, {
         }
       };
     `,
+    // Ignore when we couldn't find any calls to `context.report()`, likely because an external helper function is in use.
+    `
+      module.exports = {
+        meta: { messages: { foo: 'bar' } },
+        create(context) {}
+      };
+    `,
   ],
 
   invalid: [
@@ -314,28 +321,12 @@ ruleTester.run('no-unused-message-ids', rule, {
       ],
     },
     {
-      // messageId unused with no reports
-      code: `
-          module.exports = {
-            meta: { messages: { foo: 'hello world' } },
-            create(context) { }
-          };
-        `,
-      errors: [
-        {
-          messageId: 'unusedMessage',
-          data: { messageId: 'foo' },
-          type: 'Property',
-        },
-      ],
-    },
-    {
       // messageId unused with meta.messages in variable
       code: `
           const messages = { foo: 'hello world' };
           module.exports = {
             meta: { messages },
-            create(context) { }
+            create(context) { context.report({node, messageId: 'other'}); }
           };
         `,
       errors: [
@@ -353,7 +344,7 @@ ruleTester.run('no-unused-message-ids', rule, {
           const extraMeta = { messages: { ...extraMessages } };
           module.exports = {
             meta: { ...extraMeta },
-            create(context) { }
+            create(context) { context.report({node, messageId: 'other'}); }
           };
         `,
       errors: [


### PR DESCRIPTION
Fixes #283.

When we haven't found any violation reporting code in a rule, we should assume the violation reporting is being handled in an external file/function, so don't flag any violations as they are likely to be false positives.

Changes:

* Adds variable `hasSeenViolationReport` for tracking whether we have seen any violation reporting code
* Renames existing variable to `hasSeenUnknownMessageId ` for clarity 