### PR TITLE
Handle spread in `context.report()` in `require-meta-has-suggestions` rule

### DIFF
--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -49,9 +49,9 @@ module.exports = {
             (node.arguments.length === 1 &&
               node.arguments[0].type === 'ObjectExpression'))
         ) {
-          const suggestProp = node.arguments[0].properties.find(
-            (prop) => utils.getKeyName(prop) === 'suggest'
-          );
+          const suggestProp = utils
+            .evaluateObjectProperties(node.arguments[0], scopeManager)
+            .find((prop) => utils.getKeyName(prop) === 'suggest');
           if (suggestProp) {
             const staticValue = getStaticValue(
               suggestProp.value,

--- a/tests/lib/rules/require-meta-has-suggestions.js
+++ b/tests/lib/rules/require-meta-has-suggestions.js
@@ -171,7 +171,7 @@ ruleTester.run('require-meta-has-suggestions', rule, {
         }
       };
     `,
-    // Unrelated spread syntax.
+    // Unrelated spread syntax in rule.
     {
       code: `
         const extra = {};
@@ -185,13 +185,23 @@ ruleTester.run('require-meta-has-suggestions', rule, {
         ecmaVersion: 9,
       },
     },
-    // Related spread.
+    // Related spread in meta.
     `
       const extra = { hasSuggestions: true };
       module.exports = {
         meta: { ...extra },
         create(context) {
           context.report({node, message, suggest: [{}]});
+        }
+      };
+    `,
+    // Spread in report.
+    `
+      module.exports = {
+        meta: { hasSuggestions: true },
+        create(context) {
+          const extra = { suggest: [{}] };
+          context.report({node, message, ...extra });
         }
       };
     `,


### PR DESCRIPTION
Fixes #281.