### PR TITLE
Handle spread in `context.report()` in `require-meta-fixable` rule

### DIFF
--- a/lib/rules/require-meta-fixable.js
+++ b/lib/rules/require-meta-fixable.js
@@ -73,10 +73,9 @@ module.exports = {
           node.callee.property.name === 'report' &&
           (node.arguments.length > 4 ||
             (node.arguments.length === 1 &&
-              node.arguments[0].type === 'ObjectExpression' &&
-              node.arguments[0].properties.some(
-                (prop) => utils.getKeyName(prop) === 'fix'
-              )))
+              utils
+                .evaluateObjectProperties(node.arguments[0], scopeManager)
+                .some((prop) => utils.getKeyName(prop) === 'fix')))
         ) {
           usesFixFunctions = true;
         }

--- a/tests/lib/rules/require-meta-fixable.js
+++ b/tests/lib/rules/require-meta-fixable.js
@@ -189,7 +189,7 @@ ruleTester.run('require-meta-fixable', rule, {
       `,
       options: [{ catchNoFixerButFixableProperty: true }],
     },
-    // Spread.
+    // Spread in meta.
     `
       const extra = { 'fixable': 'code' };
       module.exports = {
@@ -199,6 +199,19 @@ ruleTester.run('require-meta-fixable', rule, {
         }
       };
     `,
+    // Spread in report.
+    {
+      code: `
+      module.exports = {
+        meta: { fixable: 'code' },
+        create(context) {
+          const extra = { fix: foo };
+          context.report({node, message, ...extra});
+        }
+      };
+    `,
+      options: [{ catchNoFixerButFixableProperty: true }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Very similar fix as to #287.