### PR TITLE
Ensure rules bail out early when no rule present

### DIFF
--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -36,6 +36,9 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const info = getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
 
     const order = context.options[0] || [
       'type',
@@ -50,7 +53,7 @@ module.exports = {
 
     return {
       Program() {
-        if (!info || !info.meta || info.meta.properties.length < 2) {
+        if (!info.meta || info.meta.properties.length < 2) {
           return;
         }
 

--- a/lib/rules/no-missing-message-ids.js
+++ b/lib/rules/no-missing-message-ids.js
@@ -29,6 +29,9 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
 
     const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
 

--- a/lib/rules/no-missing-placeholders.js
+++ b/lib/rules/no-missing-placeholders.js
@@ -37,6 +37,10 @@ module.exports = {
     let contextIdentifiers;
 
     const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
+
     const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
 
     return {

--- a/lib/rules/no-unused-message-ids.js
+++ b/lib/rules/no-unused-message-ids.js
@@ -27,6 +27,9 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     const info = utils.getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
 
     const messageIdsUsed = new Set();
     let contextIdentifiers;

--- a/lib/rules/no-unused-placeholders.js
+++ b/lib/rules/no-unused-placeholders.js
@@ -37,6 +37,9 @@ module.exports = {
     let contextIdentifiers;
 
     const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
     const messagesNode = utils.getMessagesNode(ruleInfo, scopeManager);
 
     return {

--- a/lib/rules/prefer-message-ids.js
+++ b/lib/rules/prefer-message-ids.js
@@ -30,6 +30,9 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const info = utils.getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
 
     let contextIdentifiers;
 
@@ -43,10 +46,6 @@ module.exports = {
           sourceCode.scopeManager,
           ast
         );
-
-        if (info === null) {
-          return;
-        }
 
         const metaNode = info.meta;
         const messagesNode =

--- a/lib/rules/prefer-object-rule.js
+++ b/lib/rules/prefer-object-rule.js
@@ -34,10 +34,13 @@ module.exports = {
 
     const sourceCode = context.getSourceCode();
     const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
 
     return {
       Program() {
-        if (!ruleInfo || ruleInfo.isNewStyle) {
+        if (ruleInfo.isNewStyle) {
           return;
         }
 

--- a/lib/rules/report-message-format.js
+++ b/lib/rules/report-message-format.js
@@ -57,18 +57,23 @@ module.exports = {
       }
     }
 
+    const sourceCode = context.getSourceCode();
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
+
     // ----------------------------------------------------------------------
     // Public
     // ----------------------------------------------------------------------
 
     return {
       Program(ast) {
-        const sourceCode = context.getSourceCode();
         contextIdentifiers = utils.getContextIdentifiers(
           sourceCode.scopeManager,
           ast
         );
-        const ruleInfo = utils.getRuleInfo(sourceCode);
+
         const messagesObject =
           ruleInfo &&
           ruleInfo.meta &&

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -42,15 +42,15 @@ module.exports = {
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
+    const info = utils.getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
+
     return {
       Program() {
-        const sourceCode = context.getSourceCode();
         const { scopeManager } = sourceCode;
-        const info = utils.getRuleInfo(sourceCode);
-
-        if (info === null) {
-          return;
-        }
 
         const pattern =
           context.options[0] && context.options[0].pattern

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -72,15 +72,15 @@ module.exports = {
       );
     }
 
+    const sourceCode = context.getSourceCode();
+    const info = util.getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
+
     return {
       Program() {
-        const sourceCode = context.getSourceCode();
         const { scopeManager } = sourceCode;
-
-        const info = util.getRuleInfo(sourceCode);
-        if (info === null) {
-          return;
-        }
 
         const metaNode = info.meta;
         const docsPropNode = util

--- a/lib/rules/require-meta-has-suggestions.js
+++ b/lib/rules/require-meta-has-suggestions.js
@@ -32,6 +32,9 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
     let contextIdentifiers;
     let ruleReportsSuggestions;
 
@@ -56,10 +59,6 @@ module.exports = {
         return true;
       }
       return false;
-    }
-
-    if (!ruleInfo) {
-      return {};
     }
 
     return {

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -44,7 +44,7 @@ module.exports = {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
     const info = utils.getRuleInfo(sourceCode);
-    if (info === null) {
+    if (!info) {
       return {};
     }
 

--- a/lib/rules/require-meta-type.js
+++ b/lib/rules/require-meta-type.js
@@ -38,15 +38,15 @@ module.exports = {
     // Public
     // ----------------------------------------------------------------------
 
+    const sourceCode = context.getSourceCode();
+    const info = utils.getRuleInfo(sourceCode);
+    if (!info) {
+      return {};
+    }
+
     return {
       Program() {
-        const sourceCode = context.getSourceCode();
         const { scopeManager } = sourceCode;
-        const info = utils.getRuleInfo(sourceCode);
-
-        if (info === null) {
-          return;
-        }
 
         const metaNode = info.meta;
         const typeNode = utils

--- a/tests/lib/rules/consistent-output.js
+++ b/tests/lib/rules/consistent-output.js
@@ -68,6 +68,16 @@ ruleTester.run('consistent-output', rule, {
       `,
       options: ['always'],
     },
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [],
+      invalid: [{code: 'foo', output: 'baz', errors: ['bar']},{code: 'foo', errors: ['bar']}]
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [],
+      invalid: [{code: 'foo', output: 'baz', errors: ['bar']},{code: 'foo', errors: ['bar']}]
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [

--- a/tests/lib/rules/fixer-return.js
+++ b/tests/lib/rules/fixer-return.js
@@ -270,6 +270,7 @@ ruleTester.run('fixer-return', rule, {
         }
     };
     `,
+    `module.exports = {};`, // Not a rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/meta-property-ordering.js
+++ b/tests/lib/rules/meta-property-ordering.js
@@ -72,6 +72,7 @@ ruleTester.run('test-case-property-ordering', rule, {
       create() {},
     };`,
     'module.exports = { create() {} };', // No `meta`.
+    'module.exports = {};', // No rule;
   ],
 
   invalid: [

--- a/tests/lib/rules/no-deprecated-context-methods.js
+++ b/tests/lib/rules/no-deprecated-context-methods.js
@@ -32,7 +32,8 @@ ruleTester.run('no-deprecated-context-methods', rule, {
       sourceCode.getFirstToken();
       return {};
     }
-  `,
+    `,
+    `module.exports = {};`, // Not a rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-deprecated-report-api.js
+++ b/tests/lib/rules/no-deprecated-report-api.js
@@ -78,6 +78,7 @@ ruleTester.run('no-deprecated-report-api', rule, {
         }
       };
     `,
+    `module.exports = {};`, // Not a rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-identical-tests.js
+++ b/tests/lib/rules/no-identical-tests.js
@@ -67,6 +67,16 @@ ruleTester.run('no-identical-tests', rule, {
         invalid: []
       });
     `,
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [],
+      invalid: [{code: 'foo', output: 'baz', errors: ['bar']},{code: 'foo', output: 'baz', errors: ['bar']}]
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [],
+      invalid: [{code: 'foo', output: 'baz', errors: ['bar']},{code: 'foo', output: 'baz', errors: ['bar']}]
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-missing-message-ids.js
+++ b/tests/lib/rules/no-missing-message-ids.js
@@ -238,6 +238,7 @@ ruleTester.run('no-missing-message-ids', rule, {
         }
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-missing-placeholders.js
+++ b/tests/lib/rules/no-missing-placeholders.js
@@ -222,6 +222,7 @@ ruleTester.run('no-missing-placeholders', rule, {
         }
       };
     `,
+    `module.exports = {};`, // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-only-tests.js
+++ b/tests/lib/rules/no-only-tests.js
@@ -43,6 +43,16 @@ ruleTester.run('no-only-tests', rule, {
         ]
       });
     `,
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [{ code: 'foo', only: true },],
+      invalid: []
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [{ code: 'foo', only: true },],
+      invalid: []
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-unused-message-ids.js
+++ b/tests/lib/rules/no-unused-message-ids.js
@@ -271,6 +271,7 @@ ruleTester.run('no-unused-message-ids', rule, {
         }
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-unused-placeholders.js
+++ b/tests/lib/rules/no-unused-placeholders.js
@@ -197,6 +197,7 @@ ruleTester.run('no-unused-placeholders', rule, {
         }
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/no-useless-token-range.js
+++ b/tests/lib/rules/no-useless-token-range.js
@@ -81,17 +81,20 @@ const INVALID_CASES = [
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run('no-useless-token-range', rule, {
   valid: [
-    'sourceCode.getLastToken(foo).range[0]',
-    'sourceCode.getFirstToken(foo).range[1]',
-    'sourceCode.getLastToken(foo).start',
-    'sourceCode.getFirstToken(foo).end',
-    'sourceCode.getSomethingElse(foo).range[0]',
-    'notSourceCode.getFirstToken(foo).range[0]',
-    'sourceCode.getFirstToken(foo, bar).range[0]',
-    'sourceCode.getFirstToken(foo, { skip: 1 }).start',
-    'sourceCode.getLastToken(foo, bar).range[1]',
-    'sourceCode.getLastToken(foo, { skip: 1 }).end',
-  ].map(wrapRule),
+    ...[
+      'sourceCode.getLastToken(foo).range[0]',
+      'sourceCode.getFirstToken(foo).range[1]',
+      'sourceCode.getLastToken(foo).start',
+      'sourceCode.getFirstToken(foo).end',
+      'sourceCode.getSomethingElse(foo).range[0]',
+      'notSourceCode.getFirstToken(foo).range[0]',
+      'sourceCode.getFirstToken(foo, bar).range[0]',
+      'sourceCode.getFirstToken(foo, { skip: 1 }).start',
+      'sourceCode.getLastToken(foo, bar).range[1]',
+      'sourceCode.getLastToken(foo, { skip: 1 }).end',
+    ].map(wrapRule),
+    'module.exports = {};', // Not a rule.
+  ],
 
   invalid: [
     ...INVALID_CASES,

--- a/tests/lib/rules/prefer-message-ids.js
+++ b/tests/lib/rules/prefer-message-ids.js
@@ -122,6 +122,7 @@ ruleTester.run('prefer-message-ids', rule, {
         }
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-object-rule.js
+++ b/tests/lib/rules/prefer-object-rule.js
@@ -79,6 +79,7 @@ ruleTester.run('prefer-object-rule', rule, {
       `,
       parserOptions: { sourceType: 'module' },
     },
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-output-null.js
+++ b/tests/lib/rules/prefer-output-null.js
@@ -56,6 +56,16 @@ ruleTester.run('prefer-output-null', rule, {
         ]
       });
     `,
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [],
+      invalid: [{ code: 'foo', output: 'foo' },]
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [],
+      invalid: [{ code: 'foo', output: 'foo' },]
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-placeholders.js
+++ b/tests/lib/rules/prefer-placeholders.js
@@ -114,6 +114,7 @@ ruleTester.run('prefer-placeholders', rule, {
         }
       };
     `,
+    `module.exports = {};`, // Not a rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-replace-text.js
+++ b/tests/lib/rules/prefer-replace-text.js
@@ -67,6 +67,7 @@ ruleTester.run('prefer-placeholders', rule, {
         }
       };
     `,
+    `module.exports = {};`, // Not a rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/report-message-format.js
+++ b/tests/lib/rules/report-message-format.js
@@ -183,6 +183,7 @@ ruleTester.run('report-message-format', rule, {
       `,
       options: ['foo'],
     },
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/require-meta-docs-description.js
+++ b/tests/lib/rules/require-meta-docs-description.js
@@ -14,7 +14,8 @@ const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 9 } });
 ruleTester.run('require-meta-docs-description', rule, {
   valid: [
-    'foo()',
+    'foo()', // No rule.
+    'module.exports = {};', // No rule.
     `
       module.exports = {
         meta: { docs: { description: 'disallow unused variables' } },

--- a/tests/lib/rules/require-meta-docs-url.js
+++ b/tests/lib/rules/require-meta-docs-url.js
@@ -25,7 +25,8 @@ const tester = new RuleTester({
 
 tester.run('require-meta-docs-url', rule, {
   valid: [
-    'foo()',
+    'foo()', // No rule.
+    'module.exports = {};', // No rule.
     `
       module.exports.meta = {docs: {url: ""}}
       module.exports.create = function() {}

--- a/tests/lib/rules/require-meta-schema.js
+++ b/tests/lib/rules/require-meta-schema.js
@@ -154,6 +154,7 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) {}
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/require-meta-type.js
+++ b/tests/lib/rules/require-meta-type.js
@@ -84,6 +84,7 @@ ruleTester.run('require-meta-type', rule, {
         create(context) {}
       };
     `,
+    'module.exports = {};', // No rule.
   ],
 
   invalid: [

--- a/tests/lib/rules/test-case-property-ordering.js
+++ b/tests/lib/rules/test-case-property-ordering.js
@@ -58,6 +58,16 @@ ruleTester.run('test-case-property-ordering', rule, {
       `,
       options: [['code', 'errors', 'options', 'output', 'parserOptions']],
     },
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [{ code: "foo", options: ["baz"], output: "bar", }],
+      invalid: []
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [{ code: "foo", options: ["baz"], output: "bar", }],
+      invalid: []
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [

--- a/tests/lib/rules/test-case-shorthand-strings.js
+++ b/tests/lib/rules/test-case-shorthand-strings.js
@@ -136,6 +136,16 @@ ruleTester.run('test-case-shorthand-strings', rule, {
       code: getTestCases(['"foo"', "'bar'", '`baz`']),
       options: ['consistent-as-needed'],
     },
+    `
+    new NotRuleTester().run('foo', bar, {
+      valid: [{ code: 'foo' }],
+      invalid: []
+    });`, // Not RuleTester.
+    `
+    new RuleTester().notRun('foo', bar, {
+      valid: [{ code: 'foo' }],
+      invalid: []
+    });`, // Not run() from RuleTester.
   ],
 
   invalid: [


### PR DESCRIPTION
For rules that use `utils.getRuleInfo()` to get the current rule to operate on, bail out early if no rule is found (and add tests for this). Benefits include:
* Simplifies rule implementations
* Avoids performance hit from needlessly running node visitors on a non-rule
* Reduces chance of bugs from running on a non-rule