### PR TITLE
Rename `info` to `ruleInfo`

### DIFF
--- a/lib/rules/meta-property-ordering.js
+++ b/lib/rules/meta-property-ordering.js
@@ -35,8 +35,8 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-    const info = getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -53,11 +53,11 @@ module.exports = {
 
     return {
       Program() {
-        if (!info.meta || info.meta.properties.length < 2) {
+        if (!ruleInfo.meta || ruleInfo.meta.properties.length < 2) {
           return;
         }
 
-        const props = info.meta.properties;
+        const props = ruleInfo.meta.properties;
 
         let last;
 

--- a/lib/rules/no-unused-message-ids.js
+++ b/lib/rules/no-unused-message-ids.js
@@ -26,8 +26,8 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
-    const info = utils.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -36,7 +36,7 @@ module.exports = {
     let hasSeenUnknownMessageId = false;
     let hasSeenViolationReport = false;
 
-    const messageIdNodes = utils.getMessageIdNodes(info, scopeManager);
+    const messageIdNodes = utils.getMessageIdNodes(ruleInfo, scopeManager);
     if (!messageIdNodes) {
       // If we can't find `meta.messages`, disable the rule.
       return {};

--- a/lib/rules/prefer-message-ids.js
+++ b/lib/rules/prefer-message-ids.js
@@ -29,8 +29,8 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-    const info = utils.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -47,7 +47,7 @@ module.exports = {
           ast
         );
 
-        const metaNode = info.meta;
+        const metaNode = ruleInfo.meta;
         const messagesNode =
           metaNode &&
           metaNode.properties &&
@@ -57,7 +57,7 @@ module.exports = {
 
         if (!messagesNode) {
           context.report({
-            node: metaNode || info.create,
+            node: metaNode || ruleInfo.create,
             messageId: 'messagesMissing',
           });
           return;

--- a/lib/rules/require-meta-docs-description.js
+++ b/lib/rules/require-meta-docs-description.js
@@ -43,8 +43,8 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
-    const info = utils.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -57,7 +57,7 @@ module.exports = {
             ? new RegExp(context.options[0].pattern)
             : DEFAULT_PATTERN;
 
-        const metaNode = info.meta;
+        const metaNode = ruleInfo.meta;
         const docsNode = utils
           .evaluateObjectProperties(metaNode, scopeManager)
           .find((p) => p.type === 'Property' && utils.getKeyName(p) === 'docs');
@@ -71,7 +71,7 @@ module.exports = {
 
         if (!descriptionNode) {
           context.report({
-            node: docsNode || metaNode || info.create,
+            node: docsNode || metaNode || ruleInfo.create,
             messageId: 'missing',
           });
           return;

--- a/lib/rules/require-meta-docs-url.js
+++ b/lib/rules/require-meta-docs-url.js
@@ -73,8 +73,8 @@ module.exports = {
     }
 
     const sourceCode = context.getSourceCode();
-    const info = util.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = util.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -82,7 +82,7 @@ module.exports = {
       Program() {
         const { scopeManager } = sourceCode;
 
-        const metaNode = info.meta;
+        const metaNode = ruleInfo.meta;
         const docsPropNode = util
           .evaluateObjectProperties(metaNode, scopeManager)
           .find((p) => p.type === 'Property' && util.getKeyName(p) === 'docs');
@@ -110,7 +110,7 @@ module.exports = {
             (urlPropNode && urlPropNode.value) ||
             (docsPropNode && docsPropNode.value) ||
             metaNode ||
-            info.create,
+            ruleInfo.create,
 
           messageId: !urlPropNode
             ? 'missing'

--- a/lib/rules/require-meta-schema.js
+++ b/lib/rules/require-meta-schema.js
@@ -43,13 +43,13 @@ module.exports = {
   create(context) {
     const sourceCode = context.getSourceCode();
     const { scopeManager } = sourceCode;
-    const info = utils.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
     let contextIdentifiers;
-    const metaNode = info.meta;
+    const metaNode = ruleInfo.meta;
     let schemaNode;
 
     // Options
@@ -115,7 +115,7 @@ module.exports = {
       'Program:exit'() {
         if (!schemaNode && requireSchemaPropertyWhenOptionless) {
           context.report({
-            node: metaNode || info.create,
+            node: metaNode || ruleInfo.create,
             messageId: 'missing',
             suggest:
               !isUsingOptions &&
@@ -150,7 +150,7 @@ module.exports = {
         ) {
           isUsingOptions = true;
           context.report({
-            node: schemaNode || metaNode || info.create,
+            node: schemaNode || metaNode || ruleInfo.create,
             messageId: 'foundOptionsUsage',
           });
         }

--- a/lib/rules/require-meta-type.js
+++ b/lib/rules/require-meta-type.js
@@ -39,8 +39,8 @@ module.exports = {
     // ----------------------------------------------------------------------
 
     const sourceCode = context.getSourceCode();
-    const info = utils.getRuleInfo(sourceCode);
-    if (!info) {
+    const ruleInfo = utils.getRuleInfo(sourceCode);
+    if (!ruleInfo) {
       return {};
     }
 
@@ -48,14 +48,14 @@ module.exports = {
       Program() {
         const { scopeManager } = sourceCode;
 
-        const metaNode = info.meta;
+        const metaNode = ruleInfo.meta;
         const typeNode = utils
           .evaluateObjectProperties(metaNode, scopeManager)
           .find((p) => p.type === 'Property' && utils.getKeyName(p) === 'type');
 
         if (!typeNode) {
           context.report({
-            node: metaNode || info.create,
+            node: metaNode || ruleInfo.create,
             messageId: 'missing',
           });
           return;


### PR DESCRIPTION
In most places, we call this variable `ruleInfo` for better clarity. But in some places, we still called it just `info` which is ambiguous. 

This is an internal-only refactoring.