### PR TITLE
fix: update error message for invalid `meta.fixable` property

### DIFF
--- a/lib/rules/require-meta-fixable.ts
+++ b/lib/rules/require-meta-fixable.ts
@@ -40,8 +40,7 @@ const rule: Rule.RuleModule = {
     ],
     defaultOptions: [{ catchNoFixerButFixableProperty: false }],
     messages: {
-      invalid:
-        '`meta.fixable` must be either `code`, `whitespace`, or `undefined`.',
+      invalid: '`meta.fixable` must be `code`, `whitespace`, or `undefined`.',
       missing:
         '`meta.fixable` must be either `code` or `whitespace` for fixable rules.',
       noFixerButFixableValue:

--- a/lib/rules/require-meta-fixable.ts
+++ b/lib/rules/require-meta-fixable.ts
@@ -40,7 +40,7 @@ const rule: Rule.RuleModule = {
     ],
     defaultOptions: [{ catchNoFixerButFixableProperty: false }],
     messages: {
-      invalid: '`meta.fixable` must be either `code`, `whitespace`, or `null`.',
+      invalid: '`meta.fixable` must be either `code`, `whitespace`, or `undefined`.',
       missing:
         '`meta.fixable` must be either `code` or `whitespace` for fixable rules.',
       noFixerButFixableValue:

--- a/lib/rules/require-meta-fixable.ts
+++ b/lib/rules/require-meta-fixable.ts
@@ -40,7 +40,8 @@ const rule: Rule.RuleModule = {
     ],
     defaultOptions: [{ catchNoFixerButFixableProperty: false }],
     messages: {
-      invalid: '`meta.fixable` must be either `code`, `whitespace`, or `undefined`.',
+      invalid:
+        '`meta.fixable` must be either `code`, `whitespace`, or `undefined`.',
       missing:
         '`meta.fixable` must be either `code` or `whitespace` for fixable rules.',
       noFixerButFixableValue:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

This PR fixes an issue where the `require-meta-fixable` rule shows an incorrect error message for the `invalid` message type.

According to the `@eslint/core` type used by ESLint, the `fixable` property cannot be `null`. It may be `undefined`, and when present it must be either `"code"` or `"whitespace"`.

Passing `null` might work, but using `undefined` seems more correct since the type restricts the value.

- https://github.com/eslint/rewrite/blob/main/packages/core/src/types.ts#L93

```ts
/**
 * The type of fix the rule can provide:
 * - `code` means the rule can fix syntax.
 * - `whitespace` means the rule can fix spacing and indentation.
 */
export type RuleFixType = "code" | "whitespace";
```

- https://github.com/eslint/rewrite/blob/main/packages/core/src/types.ts#L189

```ts
        // ...
        
	/**
	 * Indicates if the rule is fixable, and if so, what type of fix it provides.
	 */
	fixable?: RuleFixType | undefined;
	
	// ...
```

#### What changes did you make? (Give an overview)

This PR fixes an issue where the `require-meta-fixable` rule shows an incorrect error message for the `invalid` message type.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A