### PR TITLE
chore: update dependency tsdown to ^0.21.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "npm-package-json-lint": "^9.0.0",
     "npm-run-all2": "^8.0.0",
     "prettier": "3.8.3",
-    "tsdown": "^0.13.3",
+    "tsdown": "^0.21.10",
     "typescript": "^5.9.2",
     "typescript-eslint": "8.59.4",
     "vitest": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "7.4.0",
   "description": "An ESLint plugin for linting ESLint plugins",
   "author": "Teddy Katz",
-  "main": "./dist/index.js",
+  "main": "./dist/index.mjs",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
+    ".": "./dist/index.mjs",
     "./package.json": "./package.json"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary

Updates tsdown from `^0.13.3` to `^0.21.10` — the **highest version compatible with the project's supported Node versions**.

This supersedes #547 (renovate's bump to `^0.22.0`), which would break CI. **tsdown 0.22.0 dropped Node 20 support**: its engines became `^22.18.0 || >=24.0.0`, conflicting with:

- This project's `engines`: `^20.19.0 || ^22.13.0 || >=24.0.0`
- The CI matrix, which tests Node `20`, `20.19.0`, and `22.13.0`

Installing tsdown 0.22.x on those versions fails the engine check. Capping at `0.21.10` (engines `>=20.19.0`) keeps Node 20 working until we decide to drop it.

closes #547.

## tsdown changes that impact us (0.13.3 → 0.21.10)

- **ESM output extension changed to `.mjs` (and dts to `.d.mts`).** The build now emits `dist/index.mjs` + `dist/index.d.mts` instead of `dist/index.js`. This required updating `main`/`exports` (see next section).
- **Node 20 deprecation warning** ([v0.21.0](https://github.com/rolldown/tsdown/releases/tag/v0.21.0)): tsdown now warns when run on Node < 22.18.0. It still **works** on Node 20 (this is why we can use 0.21.10). The `build`/`lint` CI jobs run on `lts/*`, so they won't see the warning; only local dev on Node 20 might. (0.22 turns this deprecation into a hard drop.)
- **`failOnWarn` default is `false` again** ([v0.21.0](https://github.com/rolldown/tsdown/releases/tag/v0.21.0)): between [v0.17.0](https://github.com/rolldown/tsdown/releases/tag/v0.17.0) and v0.20.x the default was `'ci-only'` (warnings fail the build in CI); it reverted to `false` in 0.21.0. No config change needed on our side, and no surprise CI failures from build warnings.
- **`deps` config namespace** ([v0.21.0](https://github.com/rolldown/tsdown/releases/tag/v0.21.0)): `external`/`noExternal` etc. are renamed under `deps.*`. We don't set any of these in `tsdown.config.ts`, so no change needed.
- **Underlying rolldown bundler** moved onto the 1.0.0-rc line across 0.21.x (GA in 0.22). Build output verified equivalent for our entry points.
- Not relevant to us: CSS was extracted to `@tsdown/css` ([v0.21.1](https://github.com/rolldown/tsdown/releases/tag/v0.21.1)) and experimental SEA `exe` bundling was added — we use neither.

### Release notes

- Full diff: https://github.com/rolldown/tsdown/compare/v0.13.3...v0.21.10
- All releases: https://github.com/rolldown/tsdown/releases
- Key releases: [v0.21.0](https://github.com/rolldown/tsdown/releases/tag/v0.21.0) · [v0.19.0](https://github.com/rolldown/tsdown/releases/tag/v0.19.0) · [v0.17.0](https://github.com/rolldown/tsdown/releases/tag/v0.17.0)

## Output filename change (safe, non-breaking)

`main`/`exports` are updated to point at `./dist/index.mjs` to match tsdown's new output (the matching `.d.mts` types resolve automatically alongside it).

This is **not a breaking change for consumers**:

- **The filename is never referenced by consumers.** They import via the `eslint-plugin-eslint-plugin` specifier, resolved through the `exports` `.` entry — the target filename is an implementation detail. The import specifier is unchanged.
- **Module semantics are identical.** The package is already `"type": "module"`, so `dist/index.js` was already ESM; `.mjs` is also ESM. No CJS/ESM interop change, no dual-package hazard.
- **Deep imports were already blocked.** `exports` only exposes `.` and `./package.json`, so nobody could import `dist/index.js` directly — renaming it breaks no supported entry point.
- **Types still resolve.** No explicit `types` field is needed; TypeScript picks up `index.d.mts` next to `index.mjs` (verified by the `all-typed-config` e2e fixture, which runs `tsc`).
- **The edit is mandatory, not additive.** Once the output extension changes, `package.json` must follow or it points at a non-existent file (which is exactly what CI caught before this fix).

## Test plan

- [x] `npm run build` produces dist output (80 files) with tsdown 0.21.10
- [x] `npm run e2e` — both fixtures pass (`all`, `all-typed-config`)
- [x] `npm run lint` passes (including `eslint-doc-generator --check`)
- [x] `npm pack` ships `dist/index.mjs` + `dist/index.d.mts`; installing the tarball in a clean project resolves both the runtime import and the types (`tsc --moduleResolution nodenext`)