### PR TITLE
fix: Avoid false positives with unresolved meta object spreads in `require-meta-*` rules

### DIFF
--- a/lib/rules/prefer-message-ids.ts
+++ b/lib/rules/prefer-message-ids.ts
@@ -4,10 +4,12 @@ import type { Node } from 'estree';
 
 import {
   collectReportViolationAndSuggestionData,
+  evaluateObjectProperties,
   getContextIdentifiers,
   getKeyName,
   getReportInfo,
   getRuleInfo,
+  hasUnresolvedObjectSpread,
 } from '../utils.ts';
 
 // ------------------------------------------------------------------------------
@@ -55,15 +57,21 @@ const rule: Rule.RuleModule = {
         );
 
         const metaNode = ruleInfo.meta;
+        const metaProperties = evaluateObjectProperties(
+          metaNode,
+          sourceCode.scopeManager,
+        );
         const messagesNode =
           metaNode &&
           metaNode.type === 'ObjectExpression' &&
-          metaNode.properties &&
-          metaNode.properties
+          metaProperties
             .filter((p) => p.type === 'Property')
             .find((p) => getKeyName(p) === 'messages');
 
         if (!messagesNode) {
+          if (hasUnresolvedObjectSpread(metaNode, sourceCode.scopeManager)) {
+            return;
+          }
           context.report({
             node: metaNode || ruleInfo.create,
             messageId: 'messagesMissing',

--- a/lib/rules/require-meta-fixable.ts
+++ b/lib/rules/require-meta-fixable.ts
@@ -11,6 +11,7 @@ import {
   getContextIdentifiers,
   getKeyName,
   getRuleInfo,
+  hasUnresolvedObjectSpread,
 } from '../utils.ts';
 
 // ------------------------------------------------------------------------------
@@ -83,9 +84,13 @@ const rule: Rule.RuleModule = {
       },
       'Program:exit'(ast) {
         const scope = sourceCode.getScope(ast);
+        const metaProperties = evaluateObjectProperties(
+          ruleInfo.meta,
+          scopeManager,
+        );
         const metaFixableProp =
           ruleInfo &&
-          evaluateObjectProperties(ruleInfo.meta, scopeManager)
+          metaProperties
             .filter((prop) => prop.type === 'Property')
             .find((prop) => getKeyName(prop) === 'fixable');
 
@@ -131,7 +136,11 @@ const rule: Rule.RuleModule = {
               messageId: 'noFixerButFixableValue',
             });
           }
-        } else if (!metaFixableProp && usesFixFunctions) {
+        } else if (
+          !metaFixableProp &&
+          usesFixFunctions &&
+          !hasUnresolvedObjectSpread(ruleInfo.meta, scopeManager)
+        ) {
           // Rule is fixable but is missing the `fixable` property.
           context.report({
             node: ruleInfo.meta || ruleInfo.create,

--- a/lib/rules/require-meta-schema.ts
+++ b/lib/rules/require-meta-schema.ts
@@ -6,6 +6,7 @@ import {
   getMetaSchemaNode,
   getMetaSchemaNodeProperty,
   getRuleInfo,
+  hasUnresolvedObjectSpread,
   insertProperty,
   isUndefinedIdentifier,
 } from '../utils.ts';
@@ -68,6 +69,7 @@ const rule: Rule.RuleModule = {
 
     const schemaNode = getMetaSchemaNode(metaNode, scopeManager);
     const schemaProperty = getMetaSchemaNodeProperty(schemaNode, scopeManager);
+    const metaMayHaveSchema = hasUnresolvedObjectSpread(metaNode, scopeManager);
 
     return {
       Program(ast) {
@@ -96,7 +98,11 @@ const rule: Rule.RuleModule = {
       },
 
       'Program:exit'() {
-        if (!schemaNode && requireSchemaPropertyWhenOptionless) {
+        if (
+          !schemaNode &&
+          !metaMayHaveSchema &&
+          requireSchemaPropertyWhenOptionless
+        ) {
           context.report({
             node: metaNode || ruleInfo.create,
             messageId: 'missing',
@@ -125,7 +131,7 @@ const rule: Rule.RuleModule = {
       MemberExpression(node) {
         // Check if `context.options` was used when no options were defined in `meta.schema`.
         if (
-          (hasEmptySchema || !schemaNode) &&
+          (hasEmptySchema || (!schemaNode && !metaMayHaveSchema)) &&
           node.object.type === 'Identifier' &&
           contextIdentifiers.has(node.object) &&
           node.property.type === 'Identifier' &&

--- a/lib/rules/require-meta-type.ts
+++ b/lib/rules/require-meta-type.ts
@@ -5,7 +5,12 @@
 import { getStaticValue } from '@eslint-community/eslint-utils';
 import type { Rule } from 'eslint';
 
-import { evaluateObjectProperties, getKeyName, getRuleInfo } from '../utils.ts';
+import {
+  evaluateObjectProperties,
+  getKeyName,
+  getRuleInfo,
+  hasUnresolvedObjectSpread,
+} from '../utils.ts';
 
 const VALID_TYPES = new Set(['problem', 'suggestion', 'layout']);
 
@@ -44,11 +49,15 @@ const rule: Rule.RuleModule = {
         const { scopeManager } = sourceCode;
 
         const metaNode = ruleInfo.meta;
-        const typeNode = evaluateObjectProperties(metaNode, scopeManager)
+        const metaProperties = evaluateObjectProperties(metaNode, scopeManager);
+        const typeNode = metaProperties
           .filter((p) => p.type === 'Property')
           .find((p) => getKeyName(p) === 'type');
 
         if (!typeNode) {
+          if (hasUnresolvedObjectSpread(metaNode, scopeManager)) {
+            return;
+          }
           context.report({
             node: metaNode || ruleInfo.create,
             messageId: 'missing',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -920,6 +920,57 @@ export function isSuggestionFixerFunction(
   );
 }
 
+// Spreads of these node types contribute no statically-known named property that could match a
+// rule-meta key (arrays and strings expose only numeric indices; primitives, functions, and
+// classes have no object-literal members to read). They are treated as resolved-but-empty — so a
+// genuinely missing meta key is still reported — rather than as an unknown (suppressed) spread.
+const SPREAD_TYPES_WITHOUT_NAMED_PROPERTIES = new Set([
+  'ArrayExpression',
+  'ArrowFunctionExpression',
+  'ClassExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'Literal',
+  'TemplateLiteral',
+]);
+
+type SpreadResolution =
+  | { kind: 'object'; node: ObjectExpression }
+  | { kind: 'empty' }
+  | { kind: 'unknown' };
+
+/**
+ * Classify the value that a spread element spreads, resolving an identifier one hop.
+ * - `object`: spreads an object expression (inline `...{ a: 1 }` or a variable initialized
+ *   to one) whose properties can be inspected and recursed into.
+ * - `empty`: spreads a statically-known value that cannot contribute a named property
+ *   (e.g. `...{}`, `...5`, `...[1, 2]`, `...() => {}`).
+ * - `unknown`: spreads a value whose properties cannot be determined statically
+ *   (e.g. `...foo.bar`, `...getMeta()`, an unresolvable identifier).
+ * @param argument - the spread element's argument
+ * @param scopeManager
+ */
+function resolveSpreadObject(
+  argument: Expression,
+  scopeManager: Scope.ScopeManager,
+): SpreadResolution {
+  let node: Expression | FunctionDeclaration = argument;
+  if (node.type === 'Identifier') {
+    const value = findVariableValue(node, scopeManager);
+    if (!value) {
+      return { kind: 'unknown' };
+    }
+    node = value;
+  }
+  if (node.type === 'ObjectExpression') {
+    return { kind: 'object', node };
+  }
+  if (SPREAD_TYPES_WITHOUT_NAMED_PROPERTIES.has(node.type)) {
+    return { kind: 'empty' };
+  }
+  return { kind: 'unknown' };
+}
+
 /**
  * List all properties contained in an object.
  * Evaluates and includes any properties that may be behind spreads.
@@ -931,44 +982,136 @@ export function evaluateObjectProperties(
   objectNode: Node | undefined,
   scopeManager: Scope.ScopeManager,
 ): (Property | SpreadElement)[] {
-  if (!objectNode || objectNode.type !== 'ObjectExpression') {
+  const properties = evaluateObjectPropertiesWithVisited(
+    objectNode,
+    scopeManager,
+    new Set(),
+  );
+  return deduplicatePropertiesKeepingLast(properties);
+}
+
+function evaluateObjectPropertiesWithVisited(
+  objectNode: Node | undefined,
+  scopeManager: Scope.ScopeManager,
+  visited: Set<Node>,
+): (Property | SpreadElement)[] {
+  if (
+    !objectNode ||
+    objectNode.type !== 'ObjectExpression' ||
+    visited.has(objectNode)
+  ) {
     return [];
   }
+  visited.add(objectNode);
 
-  return objectNode.properties.flatMap((property) => {
+  const properties = objectNode.properties.flatMap((property) => {
     if (property.type === 'SpreadElement') {
-      const value = findVariableValue(
-        property.argument as Identifier,
-        scopeManager,
-      );
-      if (value && value.type === 'ObjectExpression') {
-        return value.properties;
-      }
-      return [];
+      const resolution = resolveSpreadObject(property.argument, scopeManager);
+      // Recurse so properties behind nested resolvable spreads are included too;
+      // `empty`/`unknown` spreads contribute no statically-known properties.
+      return resolution.kind === 'object'
+        ? evaluateObjectPropertiesWithVisited(
+            resolution.node,
+            scopeManager,
+            visited,
+          )
+        : [];
     }
     return [property];
   });
+  visited.delete(objectNode);
+  return properties;
 }
 
+/**
+ * Drop earlier duplicate-keyed properties so the returned list matches JavaScript's
+ * "last write wins" object semantics. Without this, a key supplied by both a spread and a
+ * direct property (e.g. `{ ...{ type: 'x' }, type: 'y' }`) would appear twice, and a `.find()`
+ * lookup would pick the first (source-order) value instead of the effective one.
+ * Properties whose key cannot be determined statically are kept as-is.
+ * @param properties
+ */
+function deduplicatePropertiesKeepingLast(
+  properties: (Property | SpreadElement)[],
+): (Property | SpreadElement)[] {
+  const lastIndexByKey = new Map<string, number>();
+  properties.forEach((property, index) => {
+    if (property.type === 'Property') {
+      const keyName = getKeyName(property);
+      if (keyName !== null) {
+        lastIndexByKey.set(keyName, index);
+      }
+    }
+  });
+
+  return properties.filter((property, index) => {
+    if (property.type !== 'Property') {
+      return true;
+    }
+    const keyName = getKeyName(property);
+    return keyName === null || lastIndexByKey.get(keyName) === index;
+  });
+}
+
+/**
+ * Determine whether an object contains a spread element whose properties cannot be resolved
+ * statically (and would therefore be silently dropped by `evaluateObjectProperties()`).
+ * Resolved spreads are followed recursively, so a spread that ultimately resolves to a
+ * statically-known value — an object such as `...{}` or a non-object such as `...[1, 2]` — is
+ * NOT considered unresolved, while a spread that hides an unknown value (e.g. `...baseRule.meta`,
+ * whether directly or nested) is.
+ * @param objectNode
+ * @param scopeManager
+ * @returns whether the object has a spread whose contents cannot be determined statically
+ */
 export function hasUnresolvedObjectSpread(
   objectNode: Node | undefined,
   scopeManager: Scope.ScopeManager,
 ): boolean {
+  return hasUnresolvedObjectSpreadWithVisited(
+    objectNode,
+    scopeManager,
+    new Set(),
+  );
+}
+
+function hasUnresolvedObjectSpreadWithVisited(
+  objectNode: Node | undefined,
+  scopeManager: Scope.ScopeManager,
+  visited: Set<Node>,
+): boolean {
   if (!objectNode || objectNode.type !== 'ObjectExpression') {
     return false;
   }
+  if (visited.has(objectNode)) {
+    // Already inspected (cyclic reference); it introduces no new unresolved spread.
+    return false;
+  }
+  visited.add(objectNode);
 
-  return objectNode.properties.some((property) => {
+  const hasUnresolvedSpread = objectNode.properties.some((property) => {
     if (property.type !== 'SpreadElement') {
       return false;
     }
-    if (property.argument.type !== 'Identifier') {
+    const resolution = resolveSpreadObject(property.argument, scopeManager);
+    if (resolution.kind === 'unknown') {
+      // The spread's properties cannot be determined statically (e.g. `...baseRule.meta`).
       return true;
     }
-
-    const value = findVariableValue(property.argument, scopeManager);
-    return !value || value.type !== 'ObjectExpression';
+    if (resolution.kind === 'empty') {
+      // The spread is statically known to contribute no named property (e.g. `...{}`, `...[1]`).
+      return false;
+    }
+    // The spread resolves to an object; recurse in case that object itself spreads an
+    // unresolved value that `evaluateObjectProperties()` would later drop.
+    return hasUnresolvedObjectSpreadWithVisited(
+      resolution.node,
+      scopeManager,
+      visited,
+    );
   });
+  visited.delete(objectNode);
+  return hasUnresolvedSpread;
 }
 
 export function getMetaDocsProperty(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -950,6 +950,27 @@ export function evaluateObjectProperties(
   });
 }
 
+export function hasUnresolvedObjectSpread(
+  objectNode: Node | undefined,
+  scopeManager: Scope.ScopeManager,
+): boolean {
+  if (!objectNode || objectNode.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  return objectNode.properties.some((property) => {
+    if (property.type !== 'SpreadElement') {
+      return false;
+    }
+    if (property.argument.type !== 'Identifier') {
+      return true;
+    }
+
+    const value = findVariableValue(property.argument, scopeManager);
+    return !value || value.type !== 'ObjectExpression';
+  });
+}
+
 export function getMetaDocsProperty(
   propertyName: string,
   ruleInfo: RuleInfo,

--- a/tests/lib/rules/prefer-message-ids.ts
+++ b/tests/lib/rules/prefer-message-ids.ts
@@ -113,6 +113,16 @@ ruleTester.run('prefer-message-ids', rule, {
         }
       };
     `,
+    // `meta.messages` may come from a spread that cannot be resolved statically.
+    `
+      const baseRule = require('./base-rule');
+      module.exports = {
+        meta: { ...baseRule.meta },
+        create(context) {
+          context.report({ node, messageId: 'foo' });
+        }
+      };
+    `,
     // `context.report` with no args.
     `
       module.exports = {

--- a/tests/lib/rules/prefer-message-ids.ts
+++ b/tests/lib/rules/prefer-message-ids.ts
@@ -123,6 +123,17 @@ ruleTester.run('prefer-message-ids', rule, {
         }
       };
     `,
+    // `meta.messages` may be inherited through a variable that itself spreads an unresolvable value.
+    `
+      const baseRule = require('./base-rule');
+      const inheritedMeta = { ...baseRule.meta };
+      module.exports = {
+        meta: { ...inheritedMeta },
+        create(context) {
+          context.report({ node, messageId: 'foo' });
+        }
+      };
+    `,
     // `context.report` with no args.
     `
       module.exports = {

--- a/tests/lib/rules/require-meta-fixable.ts
+++ b/tests/lib/rules/require-meta-fixable.ts
@@ -120,6 +120,17 @@ ruleTester.run('require-meta-fixable', rule, {
         }
       };
     `,
+    // `fixable` may be inherited through a variable that itself spreads an unresolvable value.
+    `
+      const baseRule = require('./base-rule');
+      const inheritedMeta = { ...baseRule.meta };
+      module.exports = {
+        meta: { ...inheritedMeta },
+        create(context) {
+          context.report({ node, message, fix(fixer) { return fixer.remove(node); } });
+        }
+      };
+    `,
     // `fixable` uses variable but no static value available.
     `
       module.exports = {

--- a/tests/lib/rules/require-meta-fixable.ts
+++ b/tests/lib/rules/require-meta-fixable.ts
@@ -110,6 +110,16 @@ ruleTester.run('require-meta-fixable', rule, {
         }
       };
     `,
+    // Unresolved spread may contain `fixable`.
+    `
+      const baseRule = require('./base-rule');
+      module.exports = {
+        meta: { ...baseRule.meta },
+        create(context) {
+          context.report({ node, message, fix(fixer) { return fixer.remove(node); } });
+        }
+      };
+    `,
     // `fixable` uses variable but no static value available.
     `
       module.exports = {

--- a/tests/lib/rules/require-meta-schema.ts
+++ b/tests/lib/rules/require-meta-schema.ts
@@ -164,6 +164,15 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) {}
       };
     `,
+    // `schema` may be inherited through a variable that itself spreads an unresolvable value.
+    `
+      const baseRule = require('./base-rule');
+      const inheritedMeta = { ...baseRule.meta };
+      module.exports = {
+        meta: { ...inheritedMeta },
+        create(context) {}
+      };
+    `,
     'module.exports = {};', // No rule.
   ],
 

--- a/tests/lib/rules/require-meta-schema.ts
+++ b/tests/lib/rules/require-meta-schema.ts
@@ -156,6 +156,14 @@ ruleTester.run('require-meta-schema', rule, {
         create(context) {}
       };
     `,
+    // Unresolved spread may contain `schema`.
+    `
+      const baseRule = require('./base-rule');
+      module.exports = {
+        meta: { ...baseRule.meta },
+        create(context) {}
+      };
+    `,
     'module.exports = {};', // No rule.
   ],
 

--- a/tests/lib/rules/require-meta-type.ts
+++ b/tests/lib/rules/require-meta-type.ts
@@ -82,6 +82,37 @@ ruleTester.run('require-meta-type', rule, {
         create(context) {}
       };
     `,
+    // `type` is provided through an inline object spread.
+    `
+      module.exports = {
+        meta: { ...{ type: 'problem' } },
+        create(context) {}
+      };
+    `,
+    // `type` may be inherited through a variable that itself spreads an unresolvable value.
+    `
+      const baseRule = require('./base-rule');
+      const inheritedMeta = { ...baseRule.meta };
+      module.exports = {
+        meta: { ...inheritedMeta },
+        create(context) {}
+      };
+    `,
+    // A later inline-spread value overrides an earlier direct property (last write wins).
+    `
+      module.exports = {
+        meta: { type: 'invalid', ...{ type: 'problem' } },
+        create(context) {}
+      };
+    `,
+    // A repeated resolved spread after an override supplies the effective value.
+    `
+      const extra = { type: 'problem' };
+      module.exports = {
+        meta: { ...extra, type: 'invalid', ...extra },
+        create(context) {}
+      };
+    `,
     'module.exports = {};', // No rule.
     // No `create` function.
     `
@@ -107,6 +138,65 @@ ruleTester.run('require-meta-type', rule, {
           type: 'ObjectExpression',
           column: 17,
           endColumn: 19,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      // Inline empty spread is statically known and cannot provide `type`.
+      code: `
+        module.exports = {
+          meta: { ...{} },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          column: 17,
+          endColumn: 26,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      // Spread of a statically-known non-object cannot provide `type`.
+      code: `
+        const num = 5;
+        module.exports = {
+          meta: { ...num },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          column: 17,
+          endColumn: 27,
+          endLine: 4,
+          line: 4,
+        },
+      ],
+    },
+    {
+      // A later direct property overrides an earlier inline-spread value (last write wins),
+      // so the effective (invalid) `type` is what gets reported.
+      code: `
+        module.exports = {
+          meta: { ...{ type: 'problem' }, type: 'invalid' },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'unexpected',
+          type: 'Literal',
+          column: 49,
+          endColumn: 58,
           endLine: 3,
           line: 3,
         },

--- a/tests/lib/rules/require-meta-type.ts
+++ b/tests/lib/rules/require-meta-type.ts
@@ -74,6 +74,14 @@ ruleTester.run('require-meta-type', rule, {
         create(context) {}
       };
     `,
+    // Unresolved spread may contain `type`.
+    `
+      const baseRule = require('./base-rule');
+      module.exports = {
+        meta: { ...baseRule.meta },
+        create(context) {}
+      };
+    `,
     'module.exports = {};', // No rule.
     // No `create` function.
     `

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -1746,6 +1746,51 @@ describe('utils', () => {
       const result = utils.evaluateObjectProperties(ast.body[0], scopeManager);
       assert.deepEqual(result, []);
     });
+
+    it('detects unresolved object spreads', () => {
+      const getObjectExpression = (
+        ast: Program,
+        bodyElement: number,
+      ): ObjectExpression =>
+        (ast.body[bodyElement] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `
+        const extra = { a: 123 };
+        const known = { ...extra };
+        const unknownMember = { ...baseRule.meta };
+        const unknownCall = { ...getMeta() };
+        `,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+
+      assert.strictEqual(
+        utils.hasUnresolvedObjectSpread(
+          getObjectExpression(ast, 1),
+          scopeManager,
+        ),
+        false,
+      );
+      assert.strictEqual(
+        utils.hasUnresolvedObjectSpread(
+          getObjectExpression(ast, 2),
+          scopeManager,
+        ),
+        true,
+      );
+      assert.strictEqual(
+        utils.hasUnresolvedObjectSpread(
+          getObjectExpression(ast, 3),
+          scopeManager,
+        ),
+        true,
+      );
+    });
   });
 
   describe('getMessagesNode', () => {

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -1706,6 +1706,104 @@ describe('utils', () => {
       ]);
     });
 
+    it('expands inline object spreads and follows nested resolvable spreads', () => {
+      const getObjectExpression = (
+        ast: Program,
+        bodyElement: number,
+      ): ObjectExpression =>
+        (ast.body[bodyElement] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `
+        const inner = { a: 123 };
+        const wrapper = { ...inner };
+        const obj = { ...{ b: 456 }, ...wrapper };
+        `,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+      const result = utils.evaluateObjectProperties(
+        getObjectExpression(ast, 2),
+        scopeManager,
+      );
+      // `...{ b: 456 }` (inline) expands to `b`, and `...wrapper` recurses
+      // through `{ ...inner }` to reach `a`.
+      assert.deepEqual(
+        result
+          .filter((property) => property.type === 'Property')
+          .map((property) => utils.getKeyName(property)),
+        ['b', 'a'],
+      );
+    });
+
+    it('deduplicates properties to the last value (matching runtime override semantics)', () => {
+      const getObjectExpression = (ast: Program): ObjectExpression =>
+        (ast.body[0] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `const obj = { type: 'first', ...{ type: 'second' }, c: 1 };`,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+      const result = utils.evaluateObjectProperties(
+        getObjectExpression(ast),
+        scopeManager,
+      );
+
+      // The duplicate `type` collapses to a single entry carrying the overriding value,
+      // and unrelated keys are preserved in order.
+      assert.deepEqual(
+        result
+          .filter((property) => property.type === 'Property')
+          .map((property) => utils.getKeyName(property)),
+        ['type', 'c'],
+      );
+      const typeProperty = result.find(
+        (property) =>
+          property.type === 'Property' && utils.getKeyName(property) === 'type',
+      ) as Property;
+      assert.strictEqual((typeProperty.value as Literal).value, 'second');
+    });
+
+    it('allows a repeated resolved spread to win after an override', () => {
+      const getObjectExpression = (
+        ast: Program,
+        bodyElement: number,
+      ): ObjectExpression =>
+        (ast.body[bodyElement] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `
+        const extra = { type: 'problem' };
+        const obj = { ...extra, type: 'invalid', ...extra };
+        `,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+      const result = utils.evaluateObjectProperties(
+        getObjectExpression(ast, 1),
+        scopeManager,
+      );
+
+      const typeProperty = result.find(
+        (property) =>
+          property.type === 'Property' && utils.getKeyName(property) === 'type',
+      ) as Property;
+      assert.strictEqual((typeProperty.value as Literal).value, 'problem');
+    });
+
     it('behaves correctly with non-variable spreads', () => {
       const getObjectExpression = (ast: Program): ObjectExpression =>
         (ast.body[1] as VariableDeclaration).declarations[0]
@@ -1786,6 +1884,107 @@ describe('utils', () => {
       assert.strictEqual(
         utils.hasUnresolvedObjectSpread(
           getObjectExpression(ast, 3),
+          scopeManager,
+        ),
+        true,
+      );
+    });
+
+    it('follows resolved object spreads recursively', () => {
+      const getObjectExpression = (
+        ast: Program,
+        bodyElement: number,
+      ): ObjectExpression =>
+        (ast.body[bodyElement] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `
+        const extra = { a: 123 };
+        const resolvedIdentifier = { ...extra };
+        const inlineEmpty = { ...{} };
+        const inlineObject = { ...{ a: 1 } };
+        const nestedResolved = { ...resolvedIdentifier };
+        const inheritedMeta = { ...baseRule.meta };
+        const nestedUnresolved = { ...inheritedMeta };
+        const inlineHidesUnknown = { ...{ ...baseRule.meta } };
+        const cyclic = { ...cyclic };
+        `,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+
+      // Spreads that resolve to known objects (directly, after following an
+      // identifier, or through a self-referential cycle) are not unresolved.
+      for (const index of [1, 2, 3, 4, 8]) {
+        assert.strictEqual(
+          utils.hasUnresolvedObjectSpread(
+            getObjectExpression(ast, index),
+            scopeManager,
+          ),
+          false,
+          `body[${index}] should be treated as resolved`,
+        );
+      }
+      // Spreads that hide an unknown value (directly or nested behind a
+      // resolved object) remain unresolved.
+      for (const index of [5, 6, 7]) {
+        assert.strictEqual(
+          utils.hasUnresolvedObjectSpread(
+            getObjectExpression(ast, index),
+            scopeManager,
+          ),
+          true,
+          `body[${index}] should be treated as unresolved`,
+        );
+      }
+    });
+
+    it('treats spreads of statically-known non-objects as resolved', () => {
+      const getObjectExpression = (
+        ast: Program,
+        bodyElement: number,
+      ): ObjectExpression =>
+        (ast.body[bodyElement] as VariableDeclaration).declarations[0]
+          .init as ObjectExpression;
+
+      const ast = espree.parse(
+        `
+        const num = 5;
+        const arr = [1, 2];
+        function fn() {}
+        const fromNumber = { ...num };
+        const fromArray = { ...arr };
+        const fromFunction = { ...fn };
+        const fromInlineArray = { ...[1, 2] };
+        const fromUnknownCall = { ...getMeta() };
+        `,
+        {
+          ecmaVersion: 9,
+          range: true,
+        },
+      ) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+
+      // A spread of a statically-known non-object cannot supply a named property, so it is
+      // resolved (not unknown) — a genuinely missing meta property must still be reported.
+      for (const index of [3, 4, 5, 6]) {
+        assert.strictEqual(
+          utils.hasUnresolvedObjectSpread(
+            getObjectExpression(ast, index),
+            scopeManager,
+          ),
+          false,
+          `body[${index}] should be treated as resolved`,
+        );
+      }
+      // A call expression's result is genuinely indeterminate.
+      assert.strictEqual(
+        utils.hasUnresolvedObjectSpread(
+          getObjectExpression(ast, 7),
           scopeManager,
         ),
         true,


### PR DESCRIPTION
The `require-meta-*` rules could report missing meta properties when a rule used an unresolved spread like `meta: { ...baseRule.meta }`.

This suppresses the missing-property report for the affected meta rules only when the property is absent and the meta object contains an unresolved object spread. I checked the negative control with the expected false positives, then ran the full suite with 1,186 tests passing and coverage thresholds met.

Fixes #274

BEGIN_COMMIT_OVERRIDE
fix: Avoid false positives with unresolved meta object spreads in `require-meta-*` rules
END_COMMIT_OVERRIDE