### PR TITLE
fix: Avoid false positives for external meta docs in `require-meta-*` rules

### DIFF
--- a/lib/rules/require-meta-docs-description.ts
+++ b/lib/rules/require-meta-docs-description.ts
@@ -52,12 +52,16 @@ const rule: Rule.RuleModule = {
         const { scopeManager } = sourceCode;
 
         const {
+          docsPropertyMayExist,
           docsNode,
           metaNode,
           metaPropertyNode: descriptionNode,
         } = getMetaDocsProperty('description', ruleInfo, scopeManager);
 
         if (!descriptionNode) {
+          if (docsPropertyMayExist) {
+            return;
+          }
           context.report({
             node: docsNode || metaNode || ruleInfo.create,
             messageId: 'missing',

--- a/lib/rules/require-meta-docs-description.ts
+++ b/lib/rules/require-meta-docs-description.ts
@@ -52,14 +52,14 @@ const rule: Rule.RuleModule = {
         const { scopeManager } = sourceCode;
 
         const {
-          docsPropertyMayExist,
+          docsMayHaveUnknownProperties,
           docsNode,
           metaNode,
           metaPropertyNode: descriptionNode,
         } = getMetaDocsProperty('description', ruleInfo, scopeManager);
 
         if (!descriptionNode) {
-          if (docsPropertyMayExist) {
+          if (docsMayHaveUnknownProperties) {
             return;
           }
           context.report({

--- a/lib/rules/require-meta-docs-recommended.ts
+++ b/lib/rules/require-meta-docs-recommended.ts
@@ -74,14 +74,14 @@ const rule: Rule.RuleModule = {
 
     const { scopeManager } = sourceCode;
     const {
-      docsPropertyMayExist,
+      docsMayHaveUnknownProperties,
       docsNode,
       metaNode,
       metaPropertyNode: descriptionNode,
     } = getMetaDocsProperty('recommended', ruleInfo, scopeManager);
 
     if (!descriptionNode) {
-      if (docsPropertyMayExist) {
+      if (docsMayHaveUnknownProperties) {
         return {};
       }
       const docNodeValue = docsNode?.value;

--- a/lib/rules/require-meta-docs-recommended.ts
+++ b/lib/rules/require-meta-docs-recommended.ts
@@ -74,12 +74,16 @@ const rule: Rule.RuleModule = {
 
     const { scopeManager } = sourceCode;
     const {
+      docsPropertyMayExist,
       docsNode,
       metaNode,
       metaPropertyNode: descriptionNode,
     } = getMetaDocsProperty('recommended', ruleInfo, scopeManager);
 
     if (!descriptionNode) {
+      if (docsPropertyMayExist) {
+        return {};
+      }
       const docNodeValue = docsNode?.value;
       const suggestions: Rule.SuggestionReportDescriptor[] =
         docNodeValue?.type === 'ObjectExpression'

--- a/lib/rules/require-meta-docs-url.ts
+++ b/lib/rules/require-meta-docs-url.ts
@@ -89,6 +89,7 @@ const rule: Rule.RuleModule = {
         const { scopeManager } = sourceCode;
 
         const {
+          docsPropertyMayExist,
           docsNode,
           metaNode,
           metaPropertyNode: urlPropNode,
@@ -99,6 +100,10 @@ const rule: Rule.RuleModule = {
           : undefined;
         if (urlPropNode && !staticValue) {
           // Ignore non-static values since we can't determine what they look like.
+          return;
+        }
+
+        if (!urlPropNode && docsPropertyMayExist) {
           return;
         }
 

--- a/lib/rules/require-meta-docs-url.ts
+++ b/lib/rules/require-meta-docs-url.ts
@@ -89,7 +89,7 @@ const rule: Rule.RuleModule = {
         const { scopeManager } = sourceCode;
 
         const {
-          docsPropertyMayExist,
+          docsMayHaveUnknownProperties,
           docsNode,
           metaNode,
           metaPropertyNode: urlPropNode,
@@ -103,7 +103,7 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        if (!urlPropNode && docsPropertyMayExist) {
+        if (!urlPropNode && docsMayHaveUnknownProperties) {
           return;
         }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,7 +75,7 @@ export type ViolationAndSuppressionData = {
 };
 
 export type MetaDocsProperty = {
-  docsPropertyMayExist: boolean;
+  docsMayHaveUnknownProperties: boolean;
   docsNode: Property | undefined;
   metaNode: Node | undefined;
   metaPropertyNode: Property | undefined;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,6 +75,7 @@ export type ViolationAndSuppressionData = {
 };
 
 export type MetaDocsProperty = {
+  docsPropertyMayExist: boolean;
   docsNode: Property | undefined;
   metaNode: Node | undefined;
   metaPropertyNode: Property | undefined;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -971,61 +971,6 @@ function resolveSpreadObject(
   return { kind: 'unknown' };
 }
 
-function objectValueMayComeFromExternalModule(
-  value: Expression,
-  scopeManager: Scope.ScopeManager,
-  visited = new Set<Node>(),
-): boolean {
-  if (visited.has(value)) {
-    return false;
-  }
-  visited.add(value);
-
-  if (value.type === 'Identifier') {
-    const variable = findVariable(
-      scopeManager.acquire(value) || scopeManager.globalScope!,
-      value,
-    );
-    if (
-      variable?.defs.some((definition) => definition.type === 'ImportBinding')
-    ) {
-      return true;
-    }
-    const resolvedValue = findVariableValue(value, scopeManager);
-    return resolvedValue?.type === 'FunctionDeclaration'
-      ? false
-      : Boolean(
-          resolvedValue &&
-          objectValueMayComeFromExternalModule(
-            resolvedValue,
-            scopeManager,
-            visited,
-          ),
-        );
-  }
-
-  if (
-    value.type === 'CallExpression' &&
-    value.callee.type === 'Identifier' &&
-    value.callee.name === 'require'
-  ) {
-    return true;
-  }
-
-  return (
-    value.type === 'ObjectExpression' &&
-    value.properties.some(
-      (property) =>
-        property.type === 'SpreadElement' &&
-        objectValueMayComeFromExternalModule(
-          property.argument,
-          scopeManager,
-          visited,
-        ),
-    )
-  );
-}
-
 /**
  * List all properties contained in an object.
  * Evaluates and includes any properties that may be behind spreads.
@@ -1193,17 +1138,15 @@ export function getMetaDocsProperty(
     .filter((node) => node.type === 'Property')
     .find((p) => getKeyName(p) === propertyName);
 
-  const docsPropertyMayExist = Boolean(
+  const docsMayHaveUnknownProperties = Boolean(
     docsNode &&
-    objectValueMayComeFromExternalModule(
-      docsNode.value as Expression,
-      scopeManager,
-    ),
+    (docsResolution?.kind === 'unknown' ||
+      hasUnresolvedObjectSpread(docsObjectNode, scopeManager)),
   );
 
   return {
     docsNode,
-    docsPropertyMayExist,
+    docsMayHaveUnknownProperties,
     metaNode,
     metaPropertyNode,
   };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -971,6 +971,61 @@ function resolveSpreadObject(
   return { kind: 'unknown' };
 }
 
+function objectValueMayComeFromExternalModule(
+  value: Expression,
+  scopeManager: Scope.ScopeManager,
+  visited = new Set<Node>(),
+): boolean {
+  if (visited.has(value)) {
+    return false;
+  }
+  visited.add(value);
+
+  if (value.type === 'Identifier') {
+    const variable = findVariable(
+      scopeManager.acquire(value) || scopeManager.globalScope!,
+      value,
+    );
+    if (
+      variable?.defs.some((definition) => definition.type === 'ImportBinding')
+    ) {
+      return true;
+    }
+    const resolvedValue = findVariableValue(value, scopeManager);
+    return resolvedValue?.type === 'FunctionDeclaration'
+      ? false
+      : Boolean(
+          resolvedValue &&
+          objectValueMayComeFromExternalModule(
+            resolvedValue,
+            scopeManager,
+            visited,
+          ),
+        );
+  }
+
+  if (
+    value.type === 'CallExpression' &&
+    value.callee.type === 'Identifier' &&
+    value.callee.name === 'require'
+  ) {
+    return true;
+  }
+
+  return (
+    value.type === 'ObjectExpression' &&
+    value.properties.some(
+      (property) =>
+        property.type === 'SpreadElement' &&
+        objectValueMayComeFromExternalModule(
+          property.argument,
+          scopeManager,
+          visited,
+        ),
+    )
+  );
+}
+
 /**
  * List all properties contained in an object.
  * Evaluates and includes any properties that may be behind spreads.
@@ -1125,14 +1180,33 @@ export function getMetaDocsProperty(
     .filter((node) => node.type === 'Property')
     .find((p) => getKeyName(p) === 'docs');
 
+  const docsResolution = docsNode
+    ? resolveSpreadObject(docsNode.value as Expression, scopeManager)
+    : undefined;
+  const docsObjectNode =
+    docsResolution?.kind === 'object' ? docsResolution.node : undefined;
+
   const metaPropertyNode = evaluateObjectProperties(
-    docsNode?.value,
+    docsObjectNode,
     scopeManager,
   )
     .filter((node) => node.type === 'Property')
     .find((p) => getKeyName(p) === propertyName);
 
-  return { docsNode, metaNode, metaPropertyNode };
+  const docsPropertyMayExist = Boolean(
+    docsNode &&
+    objectValueMayComeFromExternalModule(
+      docsNode.value as Expression,
+      scopeManager,
+    ),
+  );
+
+  return {
+    docsNode,
+    docsPropertyMayExist,
+    metaNode,
+    metaPropertyNode,
+  };
 }
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -955,6 +955,9 @@ function resolveSpreadObject(
   scopeManager: Scope.ScopeManager,
 ): SpreadResolution {
   let node: Expression | FunctionDeclaration = argument;
+  if (node.type === 'Identifier' && isUndefinedIdentifier(node)) {
+    return { kind: 'empty' };
+  }
   if (node.type === 'Identifier') {
     const value = findVariableValue(node, scopeManager);
     if (!value) {

--- a/tests/lib/rules/require-meta-docs-description.ts
+++ b/tests/lib/rules/require-meta-docs-description.ts
@@ -42,6 +42,33 @@ ruleTester.run('require-meta-docs-description', rule, {
       languageOptions: { sourceType: 'module' },
     },
     `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: baseRule.meta.docs },
+        create(context) {}
+      };
+    `,
+    `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: { ...baseRule.meta.docs } },
+        create(context) {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: getDocs() },
+        create(context) {}
+      };
+    `,
+    `
+      const docs = { description: 'disallow foo' };
+      module.exports = {
+        meta: { docs },
+        create(context) {}
+      };
+    `,
+    `
       module.exports = {
         meta: { docs: { description: 'disallow unused variables' } },
         create(context) {}
@@ -239,6 +266,26 @@ ruleTester.run('require-meta-docs-description', rule, {
           endColumn: 27,
           endLine: 3,
           line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        const docs = {};
+        module.exports = {
+          meta: { docs },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'Property',
+          column: 19,
+          endColumn: 23,
+          endLine: 4,
+          line: 4,
         },
       ],
     },

--- a/tests/lib/rules/require-meta-docs-description.ts
+++ b/tests/lib/rules/require-meta-docs-description.ts
@@ -18,6 +18,30 @@ ruleTester.run('require-meta-docs-description', rule, {
     'foo()', // No rule.
     'module.exports = {};', // No rule.
     `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs },
+        create(context) {}
+      };
+    `,
+    `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs: { ...docs } },
+        create(context) {}
+      };
+    `,
+    {
+      code: `
+        import docs from './rule.docs.js';
+        export default {
+          meta: { docs },
+          create(context) {}
+        };
+      `,
+      languageOptions: { sourceType: 'module' },
+    },
+    `
       module.exports = {
         meta: { docs: { description: 'disallow unused variables' } },
         create(context) {}

--- a/tests/lib/rules/require-meta-docs-description.ts
+++ b/tests/lib/rules/require-meta-docs-description.ts
@@ -271,6 +271,25 @@ ruleTester.run('require-meta-docs-description', rule, {
     },
     {
       code: `
+        module.exports = {
+          meta: { docs: undefined },
+          create(context) {}
+        };
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'Property',
+          column: 19,
+          endColumn: 34,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
         const docs = {};
         module.exports = {
           meta: { docs },

--- a/tests/lib/rules/require-meta-docs-recommended.ts
+++ b/tests/lib/rules/require-meta-docs-recommended.ts
@@ -35,6 +35,26 @@ ruleTester.run('require-meta-docs-recommended', rule, {
       languageOptions: { sourceType: 'module' },
     },
     `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: baseRule.meta.docs },
+        create(context) {}
+      };
+    `,
+    `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: { ...baseRule.meta.docs } },
+        create(context) {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: getDocs() },
+        create(context) {}
+      };
+    `,
+    `
       module.exports = {
         meta: { docs: { recommended: true } },
         create(context) {}

--- a/tests/lib/rules/require-meta-docs-recommended.ts
+++ b/tests/lib/rules/require-meta-docs-recommended.ts
@@ -11,6 +11,30 @@ ruleTester.run('require-meta-docs-recommended', rule, {
     'foo()',
     'module.exports = {};',
     `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs },
+        create(context) {}
+      };
+    `,
+    `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs: { ...docs } },
+        create(context) {}
+      };
+    `,
+    {
+      code: `
+        import docs from './rule.docs.js';
+        export default {
+          meta: { docs },
+          create(context) {}
+        };
+      `,
+      languageOptions: { sourceType: 'module' },
+    },
+    `
       module.exports = {
         meta: { docs: { recommended: true } },
         create(context) {}

--- a/tests/lib/rules/require-meta-docs-url.ts
+++ b/tests/lib/rules/require-meta-docs-url.ts
@@ -26,6 +26,30 @@ tester.run('require-meta-docs-url', rule, {
     'foo()', // No rule.
     'module.exports = {};', // No rule.
     `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs },
+        create() {}
+      };
+    `,
+    `
+      const docs = require('./rule.docs.js');
+      module.exports = {
+        meta: { docs: { ...docs } },
+        create() {}
+      };
+    `,
+    {
+      code: `
+        import docs from './rule.docs.js';
+        export default {
+          meta: { docs },
+          create() {}
+        };
+      `,
+      languageOptions: { sourceType: 'module' },
+    },
+    `
       module.exports.meta = {docs: {url: ""}}
       module.exports.create = function() {}
     `,

--- a/tests/lib/rules/require-meta-docs-url.ts
+++ b/tests/lib/rules/require-meta-docs-url.ts
@@ -50,6 +50,26 @@ tester.run('require-meta-docs-url', rule, {
       languageOptions: { sourceType: 'module' },
     },
     `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: baseRule.meta.docs },
+        create() {}
+      };
+    `,
+    `
+      const baseRule = require('./base-rule.js');
+      module.exports = {
+        meta: { docs: { ...baseRule.meta.docs } },
+        create() {}
+      };
+    `,
+    `
+      module.exports = {
+        meta: { docs: getDocs() },
+        create() {}
+      };
+    `,
+    `
       module.exports.meta = {docs: {url: ""}}
       module.exports.create = function() {}
     `,
@@ -335,6 +355,7 @@ tester.run('require-meta-docs-url', rule, {
     },
     {
       code: `
+        const docs = {};
         module.exports = {
           meta: {
             docs
@@ -349,8 +370,8 @@ tester.run('require-meta-docs-url', rule, {
           type: 'Identifier',
           column: 13,
           endColumn: 17,
-          endLine: 4,
-          line: 4,
+          endLine: 5,
+          line: 5,
         },
       ],
     },
@@ -513,6 +534,7 @@ tester.run('require-meta-docs-url', rule, {
     },
     {
       code: `
+        const url = {};
         module.exports = {
           meta: {
             docs: {
@@ -529,8 +551,8 @@ tester.run('require-meta-docs-url', rule, {
           type: 'ObjectExpression',
           column: 19,
           endColumn: 14,
-          endLine: 6,
-          line: 4,
+          endLine: 7,
+          line: 5,
         },
       ],
     },
@@ -691,6 +713,7 @@ tester.run('require-meta-docs-url', rule, {
     },
     {
       code: `
+        const docs = {};
         module.exports = {
           meta: {
             docs
@@ -710,8 +733,8 @@ tester.run('require-meta-docs-url', rule, {
           type: 'Identifier',
           column: 13,
           endColumn: 17,
-          endLine: 4,
-          line: 4,
+          endLine: 5,
+          line: 5,
         },
       ],
       name: "docs as variable (pattern: 'plugin-name/{{ name }}.md')",
@@ -832,6 +855,7 @@ tester.run('require-meta-docs-url', rule, {
     },
     {
       code: `
+        const url = {};
         module.exports = {
           meta: {
             docs: {
@@ -853,8 +877,8 @@ tester.run('require-meta-docs-url', rule, {
           type: 'ObjectExpression',
           column: 19,
           endColumn: 14,
-          endLine: 6,
-          line: 4,
+          endLine: 7,
+          line: 5,
         },
       ],
       name: "spread url variable (pattern: 'plugin-name/{{ name }}.md')",
@@ -1223,6 +1247,7 @@ url: "plugin-name/test.md"
     {
       filename: 'test.js',
       code: `
+        const docs = {};
         module.exports = {
           meta: {
             docs
@@ -1242,8 +1267,8 @@ url: "plugin-name/test.md"
           type: 'Identifier',
           column: 13,
           endColumn: 17,
-          endLine: 4,
-          line: 4,
+          endLine: 5,
+          line: 5,
         },
       ],
       name: "docs as variable > with filename (pattern: 'plugin-name/{{ name }}.md')",
@@ -1509,6 +1534,7 @@ url: "plugin-name/test.md",
     {
       filename: 'test.js',
       code: `
+        const url = {};
         module.exports = {
           meta: {
             docs: {
@@ -1519,6 +1545,7 @@ url: "plugin-name/test.md",
         }
       `,
       output: `
+        const url = {};
         module.exports = {
           meta: {
             docs: {
@@ -1540,8 +1567,8 @@ url: "plugin-name/test.md"
           type: 'ObjectExpression',
           column: 19,
           endColumn: 14,
-          endLine: 6,
-          line: 4,
+          endLine: 7,
+          line: 5,
         },
       ],
       name: "spread url variable > with filename (pattern: 'plugin-name/{{ name }}.md')",

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -685,6 +685,112 @@ describe('utils', () => {
     });
   });
 
+  describe('getMetaDocsProperty', () => {
+    function getDescriptionProperty(code: string) {
+      const ast = espree.parse(code, {
+        ecmaVersion: 2022,
+        range: true,
+        sourceType: 'script',
+      }) as unknown as Program;
+      const scopeManager = eslintScope.analyze(ast);
+      const ruleInfo = utils.getRuleInfo({ ast, scopeManager });
+      assert(ruleInfo);
+      return utils.getMetaDocsProperty('description', ruleInfo, scopeManager);
+    }
+
+    const cases = [
+      {
+        name: "a require'd docs identifier",
+        code: `
+          const docs = require('./rule.docs.js');
+          module.exports = { meta: { docs }, create() {} };
+        `,
+        docsMayHaveUnknownProperties: true,
+        hasMetaProperty: false,
+      },
+      {
+        name: 'a member expression',
+        code: `
+          const baseRule = require('./base-rule.js');
+          module.exports = {
+            meta: { docs: baseRule.meta.docs },
+            create() {}
+          };
+        `,
+        docsMayHaveUnknownProperties: true,
+        hasMetaProperty: false,
+      },
+      {
+        name: 'an object spreading an unknown value',
+        code: `
+          const baseRule = require('./base-rule.js');
+          module.exports = {
+            meta: { docs: { ...baseRule.meta.docs } },
+            create() {}
+          };
+        `,
+        docsMayHaveUnknownProperties: true,
+        hasMetaProperty: false,
+      },
+      {
+        name: 'a call expression',
+        code: 'module.exports = { meta: { docs: getDocs() }, create() {} };',
+        docsMayHaveUnknownProperties: true,
+        hasMetaProperty: false,
+      },
+      {
+        name: 'an inline object with the property',
+        code: `
+          module.exports = {
+            meta: { docs: { description: 'disallow foo' } },
+            create() {}
+          };
+        `,
+        docsMayHaveUnknownProperties: false,
+        hasMetaProperty: true,
+      },
+      {
+        name: 'a local object with the property',
+        code: `
+          const docs = { description: 'disallow foo' };
+          module.exports = { meta: { docs }, create() {} };
+        `,
+        docsMayHaveUnknownProperties: false,
+        hasMetaProperty: true,
+      },
+      {
+        name: 'an empty inline object',
+        code: 'module.exports = { meta: { docs: {} }, create() {} };',
+        docsMayHaveUnknownProperties: false,
+        hasMetaProperty: false,
+      },
+      {
+        name: 'an empty local object',
+        code: `
+          const docs = {};
+          module.exports = { meta: { docs }, create() {} };
+        `,
+        docsMayHaveUnknownProperties: false,
+        hasMetaProperty: false,
+      },
+    ];
+
+    for (const testCase of cases) {
+      it(testCase.name, () => {
+        const result = getDescriptionProperty(testCase.code);
+        assert.strictEqual(
+          result.docsMayHaveUnknownProperties,
+          testCase.docsMayHaveUnknownProperties,
+        );
+        if (testCase.hasMetaProperty) {
+          assert.ok(result.metaPropertyNode);
+        } else {
+          assert.strictEqual(result.metaPropertyNode, undefined);
+        }
+      });
+    }
+  });
+
   describe('getContextIdentifiers', () => {
     type ContextIdentifierMapFn = (ast: Program) => Identifier[];
     const CASES: Record<string, ContextIdentifierMapFn> = {

--- a/tests/lib/utils.ts
+++ b/tests/lib/utils.ts
@@ -739,6 +739,12 @@ describe('utils', () => {
         hasMetaProperty: false,
       },
       {
+        name: 'an explicit undefined value',
+        code: 'module.exports = { meta: { docs: undefined }, create() {} };',
+        docsMayHaveUnknownProperties: false,
+        hasMetaProperty: false,
+      },
+      {
         name: 'an inline object with the property',
         code: `
           module.exports = {


### PR DESCRIPTION
The `require-meta-docs-*` rules could report missing properties when `meta.docs` came from an imported module or spread a required docs object, even though those properties could not be inspected locally. This leaves known local objects checked as before while skipping missing-property reports for external-module-backed docs. Checked it with the three focused rule suites, the full 1,210-test suite with coverage, lint, typecheck, and build. Fixes #633


This also resolves local `meta: { docs }` references through `resolveSpreadObject()` before looking up the requested docs property, which fixes the false positive on main when `docs` is a local object constant. The review revision now reuses the existing unresolved-spread machinery to detect when `meta.docs` may contain unknown properties.
