### PR TITLE
fix: only require meta.messages when rule reports

### DIFF
--- a/docs/rules/prefer-message-ids.md
+++ b/docs/rules/prefer-message-ids.md
@@ -14,7 +14,7 @@ When reporting a rule violation, it's preferred to provide the violation message
 
 ## Rule Details
 
-This rule catches usages of the `message` property when reporting a rule violation.
+This rule catches usages of the `message` property when reporting a rule violation. `meta.messages` is only required when the rule reports violations (via `context.report()`).
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/rules/prefer-message-ids.ts
+++ b/lib/rules/prefer-message-ids.ts
@@ -43,6 +43,7 @@ const rule: Rule.RuleModule = {
     }
 
     let contextIdentifiers: Set<Node>;
+    let hasReportCall = false;
 
     // ----------------------------------------------------------------------
     // Public
@@ -50,12 +51,17 @@ const rule: Rule.RuleModule = {
 
     return {
       Program(ast) {
-        const scope = sourceCode.getScope(ast);
         contextIdentifiers = getContextIdentifiers(
           sourceCode.scopeManager,
           ast,
         );
+      },
+      'Program:exit'(ast) {
+        if (!hasReportCall) {
+          return;
+        }
 
+        const scope = sourceCode.getScope(ast);
         const metaNode = ruleInfo.meta;
         const metaProperties = evaluateObjectProperties(
           metaNode,
@@ -103,6 +109,8 @@ const rule: Rule.RuleModule = {
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'report'
         ) {
+          hasReportCall = true;
+
           const reportInfo = getReportInfo(node, context);
           if (!reportInfo) {
             return;

--- a/tests/lib/rules/prefer-message-ids.ts
+++ b/tests/lib/rules/prefer-message-ids.ts
@@ -143,6 +143,44 @@ ruleTester.run('prefer-message-ids', rule, {
         }
       };
     `,
+    // Rules that never report do not need `meta.messages`.
+    `
+      module.exports = {
+        meta: { description: 'foo' },
+        create(context) { }
+      };
+    `,
+    `
+      module.exports = {
+        meta: {
+          description: 'foo',
+          messages: {},
+        },
+        create(context) { }
+      };
+    `,
+    `
+      const messages = {};
+      module.exports = {
+        meta: {
+          description: 'foo',
+          messages,
+        },
+        create(context) { }
+      };
+    `,
+    // Issue #292: rules that only mark variables as used.
+    `
+      module.exports = {
+        create(context) {
+          return {
+            JSXIdentifier(node) {
+              context.markVariableAsUsed(node.name);
+            },
+          };
+        },
+      };
+    `,
     'module.exports = {};', // No rule.
   ],
 
@@ -261,33 +299,15 @@ ruleTester.run('prefer-message-ids', rule, {
     },
 
     {
-      // `meta.messages` missing
-      code: `
-        module.exports = {
-          meta: { description: 'foo' },
-          create(context) { }
-        };
-      `,
-      errors: [
-        {
-          messageId: 'messagesMissing',
-          type: 'ObjectExpression',
-          column: 17,
-          endColumn: 39,
-          endLine: 3,
-          line: 3,
-        },
-      ],
-    },
-    {
-      // `meta.messages` empty
+      // `meta.messages` empty but rule reports
       code: `
         module.exports = {
           meta: {
-            description: 'foo',
             messages: {},
           },
-          create(context) { }
+          create(context) {
+            context.report({ node, messageId: 'foo' });
+          }
         };
       `,
       errors: [
@@ -296,31 +316,8 @@ ruleTester.run('prefer-message-ids', rule, {
           type: 'ObjectExpression',
           column: 23,
           endColumn: 25,
-          endLine: 5,
-          line: 5,
-        },
-      ],
-    },
-    {
-      // `meta.messages` empty (in variable)
-      code: `
-        const messages = {};
-        module.exports = {
-          meta: {
-            description: 'foo',
-            messages,
-          },
-          create(context) { }
-        };
-      `,
-      errors: [
-        {
-          messageId: 'messagesMissing',
-          type: 'Identifier',
-          column: 13,
-          endColumn: 21,
-          endLine: 6,
-          line: 6,
+          endLine: 4,
+          line: 4,
         },
       ],
     },


### PR DESCRIPTION
## Summary
- `prefer-message-ids` no longer requires `meta.messages` when a rule never calls `context.report()` (e.g. rules that only call `context.markVariableAsUsed()`).
- The messages-missing/empty check now runs on `Program:exit` and is gated on whether any `context.report()` call was seen.

Fixes #292

## Test plan
- [x] `npx vitest run tests/lib/rules/prefer-message-ids.ts`
- [x] `npm run typecheck`
- [x] `npm run lint:js`
- [ ] Confirm issue repro (rule with only `markVariableAsUsed`) no longer reports


Made with [Cursor](https://cursor.com)