### PR TITLE
fix: preserve trailing comments in meta-property-ordering autofix

### DIFF
--- a/lib/rules/meta-property-ordering.ts
+++ b/lib/rules/meta-property-ordering.ts
@@ -3,7 +3,11 @@
  */
 import type { Rule } from 'eslint';
 
-import { getKeyName, getRuleInfo } from '../utils.ts';
+import {
+  createPropertyReorderFixes,
+  getKeyName,
+  getRuleInfo,
+} from '../utils.ts';
 
 const defaultOrder = [
   'type',
@@ -102,13 +106,10 @@ const rule: Rule.RuleModule = {
               order: knownProps.map(keyNameMapper).join(', '),
             },
             fix(fixer) {
-              const expectedProps = [...knownProps, ...unknownProps];
-              return props.map((prop, k) => {
-                return fixer.replaceText(
-                  prop,
-                  sourceCode.getText(expectedProps[k]),
-                );
-              });
+              return createPropertyReorderFixes(fixer, sourceCode, props, [
+                ...knownProps,
+                ...unknownProps,
+              ]);
             },
           });
         }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -798,6 +798,145 @@ export function getSourceCodeIdentifiers(
   );
 }
 
+type ObjectProperty = ObjectExpression['properties'][number];
+
+type PropertyTrailingInfo = {
+  property: ObjectProperty;
+  commaToken: ReturnType<SourceCode['getTokenAfter']>;
+  hasComma: boolean;
+  trailingComments: ReturnType<SourceCode['getCommentsAfter']>;
+  /** Source between property end and last pre-comma same-line comment (if any). */
+  beforeCommaCommentText: string;
+  /** Source between comma end and last post-comma same-line comment (if any). */
+  afterCommaCommentText: string;
+};
+
+/**
+ * Compute trailing same-line comment info for an object property.
+ * Only comments after the property (or its trailing comma) on the property's
+ * end line are considered; leading / own-line comments stay put.
+ */
+function getPropertyTrailingInfo(
+  property: ObjectProperty,
+  sourceCode: SourceCode,
+): PropertyTrailingInfo {
+  const commaToken = sourceCode.getTokenAfter(property);
+  const hasComma = commaToken?.value === ',';
+  const propertyEndLine = property.loc!.end.line;
+  const isSameLineTrailing = (
+    comment: ReturnType<SourceCode['getCommentsAfter']>[number],
+  ) => comment.loc!.start.line === propertyEndLine;
+
+  // Comments between the property and its comma (e.g. `prop /* c */,`).
+  const commentsBeforeComma = hasComma
+    ? sourceCode.getCommentsAfter(property).filter(isSameLineTrailing)
+    : [];
+  // Comments after the comma (e.g. `prop, // c`) or after the property when
+  // there is no comma (e.g. last `prop // c`).
+  const commentsAfterAnchor = sourceCode
+    .getCommentsAfter(hasComma ? commaToken! : property)
+    .filter(isSameLineTrailing);
+
+  const trailingComments = [...commentsBeforeComma, ...commentsAfterAnchor];
+
+  const beforeCommaCommentText =
+    commentsBeforeComma.length > 0
+      ? sourceCode.text.slice(
+          property.range![1],
+          commentsBeforeComma.at(-1)!.range![1],
+        )
+      : '';
+  const afterCommaCommentText =
+    commentsAfterAnchor.length > 0
+      ? sourceCode.text.slice(
+          (hasComma ? commaToken! : property).range![1],
+          commentsAfterAnchor.at(-1)!.range![1],
+        )
+      : '';
+
+  return {
+    property,
+    commaToken,
+    hasComma: Boolean(hasComma),
+    trailingComments,
+    beforeCommaCommentText,
+    afterCommaCommentText,
+  };
+}
+
+/**
+ * Build autofix edits that reorder object properties while moving trailing
+ * same-line comments with their property.
+ *
+ * Returns `null` when a line-comment move would comment-out later code on the
+ * same line (e.g. a single-line object), so the caller can still report
+ * without offering a fix.
+ * @param fixer The fixer.
+ * @param sourceCode The source code.
+ * @param slotProperties Properties in their current (slot) order.
+ * @param expectedProperties Properties in the desired order (same length).
+ */
+export function createPropertyReorderFixes(
+  fixer: Rule.RuleFixer,
+  sourceCode: SourceCode,
+  slotProperties: ObjectProperty[],
+  expectedProperties: ObjectProperty[],
+): Rule.Fix[] | null {
+  const slotInfos = slotProperties.map((property) =>
+    getPropertyTrailingInfo(property, sourceCode),
+  );
+  const expectedInfos = expectedProperties.map((property) =>
+    getPropertyTrailingInfo(property, sourceCode),
+  );
+
+  const fixes: Rule.Fix[] = [];
+
+  for (const [i, slot] of slotInfos.entries()) {
+    const expected = expectedInfos[i]!;
+    const includeComma =
+      slot.hasComma &&
+      (slot.trailingComments.length > 0 ||
+        expected.trailingComments.length > 0);
+
+    let rangeEnd = slot.property.range![1];
+    if (includeComma && slot.commaToken) {
+      rangeEnd = Math.max(rangeEnd, slot.commaToken.range![1]);
+    }
+    if (slot.trailingComments.length > 0) {
+      rangeEnd = Math.max(rangeEnd, slot.trailingComments.at(-1)!.range![1]);
+    }
+
+    if (expected.trailingComments.some((comment) => comment.type === 'Line')) {
+      const tokenAfter = sourceCode.getTokenAfter(
+        slot.trailingComments.at(-1) ??
+          (includeComma && slot.commaToken ? slot.commaToken : slot.property),
+      );
+      if (
+        tokenAfter &&
+        tokenAfter.loc!.start.line === sourceCode.getLocFromIndex(rangeEnd).line
+      ) {
+        return null;
+      }
+    }
+
+    // Assemble: property text + pre-comma comments + optional comma + post-comma comments.
+    // When the source had no comma, afterCommaCommentText is the trailing comment
+    // text directly after the property (and beforeCommaCommentText is empty).
+    let replacement = sourceCode.getText(expected.property);
+    replacement += expected.beforeCommaCommentText;
+    if (includeComma) {
+      replacement += ',';
+    }
+    replacement += expected.afterCommaCommentText;
+
+    fixes.push(
+      fixer.replaceTextRange([slot.property.range![0], rangeEnd], replacement),
+    );
+  }
+
+  return fixes;
+}
+
 /**
  * Insert a given property into a given object literal.
  * @param fixer The fixer.

--- a/tests/lib/rules/meta-property-ordering.ts
+++ b/tests/lib/rules/meta-property-ordering.ts
@@ -206,5 +206,171 @@ ruleTester.run('test-case-property-ordering', rule, {
       ],
       name: 'custom order with extra prop (options: [type, docs, fixable])',
     },
+    {
+      // Issue #295: trailing comments should move with their property.
+      code: `
+        module.exports = {
+          meta: {
+            messages,
+            schema: [], // no options
+          },
+          create() {},
+        };`,
+      output: `
+        module.exports = {
+          meta: {
+            schema: [], // no options
+            messages,
+          },
+          create() {},
+        };`,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 13,
+          endColumn: 23,
+          endLine: 5,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: {
+            messages, // message ids
+            schema: [], // no options
+          },
+          create() {},
+        };`,
+      output: `
+        module.exports = {
+          meta: {
+            schema: [], // no options
+            messages, // message ids
+          },
+          create() {},
+        };`,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 13,
+          endColumn: 23,
+          endLine: 5,
+          line: 5,
+        },
+      ],
+    },
+    {
+      // Last property with no trailing comma + trailing comment.
+      code: `
+        module.exports = {
+          meta: {
+            messages,
+            schema: [] // no options
+          },
+          create() {},
+        };`,
+      output: `
+        module.exports = {
+          meta: {
+            schema: [], // no options
+            messages
+          },
+          create() {},
+        };`,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 13,
+          endColumn: 23,
+          endLine: 5,
+          line: 5,
+        },
+      ],
+    },
+    {
+      // Block comments also travel with their property.
+      code: `
+        module.exports = {
+          meta: {
+            messages,
+            schema: [] /* no options */,
+          },
+          create() {},
+        };`,
+      output: `
+        module.exports = {
+          meta: {
+            schema: [] /* no options */,
+            messages,
+          },
+          create() {},
+        };`,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 13,
+          endColumn: 23,
+          endLine: 5,
+          line: 5,
+        },
+      ],
+    },
+    {
+      // Own-line comments stay in place.
+      code: `
+        module.exports = {
+          meta: {
+            messages,
+            // keep this comment here
+            schema: [],
+          },
+          create() {},
+        };`,
+      output: `
+        module.exports = {
+          meta: {
+            schema: [],
+            // keep this comment here
+            messages,
+          },
+          create() {},
+        };`,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 13,
+          endColumn: 23,
+          endLine: 6,
+          line: 6,
+        },
+      ],
+    },
+    {
+      // Single-line object with line comments is reported but not autofixed.
+      code: `
+        module.exports = {
+          meta: { messages, schema: [] // no options
+          },
+          create() {},
+        };`,
+      output: null,
+      errors: [
+        {
+          messageId: 'inconsistentOrder',
+          data: { order: ['schema', 'messages'].join(', ') },
+          column: 29,
+          endColumn: 39,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- `meta-property-ordering` autofix now moves trailing same-line comments with their property (previously comments stayed pinned to the old slot).
- Adds shared `createPropertyReorderFixes` helper in `lib/utils.ts` (also usable for #407 / `test-case-property-ordering`).
- Line comments on single-line objects remain reported but unfixable, to avoid commenting out later code.

Fixes #295

## Test plan
- [x] `npx vitest run tests/lib/rules/meta-property-ordering.ts`
- [x] `npm run typecheck`
- [x] `npm run lint:js`
- [ ] Confirm issue repro comment moves with `schema`


Made with [Cursor](https://cursor.com)