### PR TITLE
feat: add new rule `require-meta-languages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ export default [
 | [require-meta-docs-url](docs/rules/require-meta-docs-url.md)                                         | require rules to implement a `meta.docs.url` property                                      |     | 🔧  |     |     |
 | [require-meta-fixable](docs/rules/require-meta-fixable.md)                                           | require rules to implement a `meta.fixable` property                                       | ✅  |     |     |     |
 | [require-meta-has-suggestions](docs/rules/require-meta-has-suggestions.md)                           | require suggestable rules to implement a `meta.hasSuggestions` property                    | ✅  | 🔧  |     |     |
+| [require-meta-languages](docs/rules/require-meta-languages.md)                                       | require rules to implement a `meta.languages` property                                     |     |     |     |     |
 | [require-meta-schema](docs/rules/require-meta-schema.md)                                             | require rules to implement a `meta.schema` property                                        | ✅  |     | 💡  |     |
 | [require-meta-schema-description](docs/rules/require-meta-schema-description.md)                     | require rules `meta.schema` properties to include descriptions                             | ✅  |     |     |     |
 | [require-meta-type](docs/rules/require-meta-type.md)                                                 | require rules to implement a `meta.type` property                                          | ✅  |     |     |     |

--- a/docs/rules/require-meta-languages.md
+++ b/docs/rules/require-meta-languages.md
@@ -1,0 +1,35 @@
+# eslint-plugin/require-meta-languages
+
+📝 Require rules to implement a `meta.languages` property.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule requires ESLint rules to have a non-empty `meta.languages` array containing only strings.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint eslint-plugin/require-meta-languages: error */
+
+module.exports = {
+  meta: {},
+  create(context) {
+    /* ... */
+  },
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint eslint-plugin/require-meta-languages: error */
+
+module.exports = {
+  meta: { languages: ['js/js'] },
+  create(context) {
+    /* ... */
+  },
+};
+```

--- a/docs/rules/require-meta-languages.md
+++ b/docs/rules/require-meta-languages.md
@@ -4,6 +4,12 @@
 
 <!-- end auto-generated rule header -->
 
+ESLint v10.2.0 introduced `meta.languages` to declare which languages a rule supports, using plugin-prefixed identifiers such as `'js/js'` or `'json/json'`.
+
+When `meta.languages` is omitted, ESLint assumes the rule supports every language. This assumption is incorrect for almost all rules: a rule written for JavaScript can crash on an unfamiliar JSON or CSS AST, or silently do nothing. Declaring `meta.languages` allows ESLint to report a clear configuration-time error instead.
+
+Dynamically computed values and unresolved spreads in `meta` are skipped, matching the behavior of the other `require-meta-*` rules.
+
 ## Rule Details
 
 This rule requires ESLint rules to have a non-empty `meta.languages` array containing only strings.
@@ -33,3 +39,8 @@ module.exports = {
   },
 };
 ```
+
+## Further Reading
+
+- [ESLint v10.2.0 released](https://eslint.org/blog/2026/04/eslint-v10.2.0-released/)
+- [ESLint custom rule docs](https://eslint.org/docs/latest/extend/custom-rules)

--- a/docs/rules/require-meta-languages.md
+++ b/docs/rules/require-meta-languages.md
@@ -12,7 +12,7 @@ Dynamically computed values and unresolved spreads in `meta` are skipped, matchi
 
 ## Rule Details
 
-This rule requires ESLint rules to have a non-empty `meta.languages` array containing only strings.
+This rule requires ESLint rules to have a non-empty `meta.languages` array whose entries are valid language identifiers: either the `'*'` wildcard or a `'namespace/language'` form (such as `'js/js'`, `'json/json'`, or `'markdown/*'`), with no duplicates.
 
 Examples of **incorrect** code for this rule:
 
@@ -21,6 +21,20 @@ Examples of **incorrect** code for this rule:
 
 module.exports = {
   meta: {},
+  create(context) {
+    /* ... */
+  },
+};
+
+module.exports = {
+  meta: { languages: ['javascript'] },
+  create(context) {
+    /* ... */
+  },
+};
+
+module.exports = {
+  meta: { languages: ['js/js', 'js/js'] },
   create(context) {
     /* ... */
   },
@@ -34,6 +48,13 @@ Examples of **correct** code for this rule:
 
 module.exports = {
   meta: { languages: ['js/js'] },
+  create(context) {
+    /* ... */
+  },
+};
+
+module.exports = {
+  meta: { languages: ['markdown/*'] },
   create(context) {
     /* ... */
   },

--- a/e2e/fixtures/all-typed-config/rule.js
+++ b/e2e/fixtures/all-typed-config/rule.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
-  // eslint-disable-next-line eslint-plugin/require-meta-schema
+  // eslint-disable-next-line eslint-plugin/require-meta-schema, eslint-plugin/require-meta-languages
   meta: {
     type: 'suggestion',
     docs: {

--- a/e2e/fixtures/all/rule.js
+++ b/e2e/fixtures/all/rule.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
-  // eslint-disable-next-line eslint-plugin/require-meta-schema
+  // eslint-disable-next-line eslint-plugin/require-meta-schema, eslint-plugin/require-meta-languages
   meta: {
     type: 'suggestion',
     docs: {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -66,7 +66,7 @@ export default defineConfig([
     plugins: { 'eslint-plugin': eslintPlugin },
     extends: ['eslint-plugin/all'],
     rules: {
-      // `require-meta-languages` targets `meta.languages` (added in ESLint v10.2.0).
+      // TODO: `require-meta-languages` targets `meta.languages` (added in ESLint v10.2.0).
       // This plugin still supports ESLint 9, where `meta.languages` isn't in the rule
       // metadata types, so we don't enable this rule on our own rules yet. Re-enable
       // once the plugin's minimum ESLint version is >= 10.2.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -66,6 +66,11 @@ export default defineConfig([
     plugins: { 'eslint-plugin': eslintPlugin },
     extends: ['eslint-plugin/all'],
     rules: {
+      // `require-meta-languages` targets `meta.languages` (added in ESLint v10.2.0).
+      // This plugin still supports ESLint 9, where `meta.languages` isn't in the rule
+      // metadata types, so we don't enable this rule on our own rules yet. Re-enable
+      // once the plugin's minimum ESLint version is >= 10.2.
+      'eslint-plugin/require-meta-languages': 'off',
       'eslint-plugin/report-message-format': ['error', '^[^a-z].*.$'],
       'eslint-plugin/require-meta-docs-url': [
         'error',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -34,6 +34,7 @@ import requireMetaDocsRecommended from './rules/require-meta-docs-recommended.ts
 import requireMetaDocsUrl from './rules/require-meta-docs-url.ts';
 import requireMetaFixable from './rules/require-meta-fixable.ts';
 import requireMetaHasSuggestions from './rules/require-meta-has-suggestions.ts';
+import requireMetaLanguages from './rules/require-meta-languages.ts';
 import requireMetaSchemaDescription from './rules/require-meta-schema-description.ts';
 import requireMetaSchema from './rules/require-meta-schema.ts';
 import requireMetaType from './rules/require-meta-type.ts';
@@ -117,6 +118,7 @@ const allRules = {
   'require-meta-docs-url': requireMetaDocsUrl,
   'require-meta-fixable': requireMetaFixable,
   'require-meta-has-suggestions': requireMetaHasSuggestions,
+  'require-meta-languages': requireMetaLanguages,
   'require-meta-schema-description': requireMetaSchemaDescription,
   'require-meta-schema': requireMetaSchema,
   'require-meta-type': requireMetaType,

--- a/lib/rules/require-meta-languages.ts
+++ b/lib/rules/require-meta-languages.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview require rules to implement a `meta.languages` property
+ * @author morgan-coded
+ */
+import { getStaticValue } from '@eslint-community/eslint-utils';
+import type { Rule } from 'eslint';
+
+import {
+  evaluateObjectProperties,
+  getKeyName,
+  getRuleInfo,
+  hasUnresolvedObjectSpread,
+} from '../utils.ts';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require rules to implement a `meta.languages` property',
+      category: 'Rules',
+      recommended: false,
+      url: 'https://github.com/eslint-community/eslint-plugin-eslint-plugin/tree/HEAD/docs/rules/require-meta-languages.md',
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      missing: '`meta.languages` is required.',
+      empty: '`meta.languages` should not be empty.',
+      invalid: '`meta.languages` should be an array of strings.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const ruleInfo = getRuleInfo(sourceCode);
+    if (!ruleInfo) {
+      return {};
+    }
+
+    return {
+      Program(ast) {
+        const scope = sourceCode.getScope(ast);
+        const { scopeManager } = sourceCode;
+
+        const metaNode = ruleInfo.meta;
+        const metaProperties = evaluateObjectProperties(metaNode, scopeManager);
+        const languagesNode = metaProperties
+          .filter((p) => p.type === 'Property')
+          .find((p) => getKeyName(p) === 'languages');
+
+        if (!languagesNode) {
+          if (hasUnresolvedObjectSpread(metaNode, scopeManager)) {
+            return;
+          }
+          context.report({
+            node: metaNode || ruleInfo.create,
+            messageId: 'missing',
+          });
+          return;
+        }
+
+        const staticValue = getStaticValue(languagesNode.value, scope);
+        if (!staticValue) {
+          // Ignore non-static values since we can't determine what they look like.
+          return;
+        }
+
+        const value = staticValue.value;
+        if (
+          !Array.isArray(value) ||
+          value.some((element) => typeof element !== 'string')
+        ) {
+          context.report({ node: languagesNode.value, messageId: 'invalid' });
+          return;
+        }
+
+        if (value.length === 0) {
+          context.report({ node: languagesNode.value, messageId: 'empty' });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/lib/rules/require-meta-languages.ts
+++ b/lib/rules/require-meta-languages.ts
@@ -12,6 +12,11 @@ import {
   hasUnresolvedObjectSpread,
 } from '../utils.ts';
 
+const isValidLanguageIdentifier = (value: string): boolean =>
+  value === '*' ||
+  (value.includes('/') &&
+    value.split('/').every((segment) => segment.length > 0));
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -29,7 +34,10 @@ const rule: Rule.RuleModule = {
     messages: {
       missing: '`meta.languages` is required.',
       empty: '`meta.languages` should not be empty.',
-      invalid: '`meta.languages` should be an array of strings.',
+      invalid: '`meta.languages` should be an array.',
+      invalidLanguage:
+        "`meta.languages` entries should be `'*'` or `'namespace/language'`.",
+      duplicate: '`meta.languages` should not contain duplicate entries.',
     },
   },
 
@@ -62,6 +70,45 @@ const rule: Rule.RuleModule = {
           return;
         }
 
+        if (languagesNode.value.type === 'ArrayExpression') {
+          if (languagesNode.value.elements.length === 0) {
+            context.report({
+              node: languagesNode.value,
+              messageId: 'empty',
+            });
+            return;
+          }
+
+          const seen = new Set<string>();
+          for (const element of languagesNode.value.elements) {
+            if (element === null || element.type === 'SpreadElement') {
+              continue;
+            }
+
+            const staticValue = getStaticValue(element, scope);
+            if (!staticValue) {
+              // Ignore non-static values since we can't determine what they look like.
+              continue;
+            }
+
+            const value = staticValue.value;
+            if (
+              typeof value !== 'string' ||
+              !isValidLanguageIdentifier(value)
+            ) {
+              context.report({ node: element, messageId: 'invalidLanguage' });
+              continue;
+            }
+
+            if (seen.has(value)) {
+              context.report({ node: element, messageId: 'duplicate' });
+              continue;
+            }
+            seen.add(value);
+          }
+          return;
+        }
+
         const staticValue = getStaticValue(languagesNode.value, scope);
         if (!staticValue) {
           // Ignore non-static values since we can't determine what they look like.
@@ -69,16 +116,37 @@ const rule: Rule.RuleModule = {
         }
 
         const value = staticValue.value;
-        if (
-          !Array.isArray(value) ||
-          value.some((element) => typeof element !== 'string')
-        ) {
+        if (!Array.isArray(value)) {
           context.report({ node: languagesNode.value, messageId: 'invalid' });
           return;
         }
 
         if (value.length === 0) {
           context.report({ node: languagesNode.value, messageId: 'empty' });
+          return;
+        }
+
+        const seen = new Set<string>();
+        for (const element of value) {
+          if (
+            typeof element !== 'string' ||
+            !isValidLanguageIdentifier(element)
+          ) {
+            context.report({
+              node: languagesNode.value,
+              messageId: 'invalidLanguage',
+            });
+            return;
+          }
+
+          if (seen.has(element)) {
+            context.report({
+              node: languagesNode.value,
+              messageId: 'duplicate',
+            });
+            return;
+          }
+          seen.add(element);
         }
       },
     };

--- a/tests/lib/rules/require-meta-languages.ts
+++ b/tests/lib/rules/require-meta-languages.ts
@@ -20,6 +20,9 @@ const ruleTester = new RuleTester({
 ruleTester.run('require-meta-languages', rule, {
   valid: [
     "module.exports = { meta: { languages: ['js/js'] }, create(context) {} };",
+    "module.exports = { meta: { languages: ['*'] }, create(context) {} };",
+    "module.exports = { meta: { languages: ['markdown/*'] }, create(context) {} };",
+    "module.exports = { meta: { languages: ['@eslint/json/json'] }, create(context) {} };",
     {
       // ESM
       code: `
@@ -58,7 +61,7 @@ ruleTester.run('require-meta-languages', rule, {
     `
         const create = {};
         module.exports = {
-          meta: { languages: ['js/js'] },
+          meta: {},
           create,
         };
       `,
@@ -160,10 +163,122 @@ ruleTester.run('require-meta-languages', rule, {
       code: "module.exports = { meta: { languages: ['js/js', 123] }, create(context) {} };",
       errors: [
         {
-          messageId: 'invalid',
-          type: 'ArrayExpression',
-          column: 39,
-          endColumn: 53,
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 49,
+          endColumn: 52,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: [''] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 42,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['javascript'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 52,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 44,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js/'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 45,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['/js'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 45,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js//js'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 48,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js/js', 'js/js'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'duplicate',
+          type: 'Literal',
+          column: 49,
+          endColumn: 56,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js', 'javascript'] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 40,
+          endColumn: 44,
+          endLine: 1,
+          line: 1,
+        },
+        {
+          messageId: 'invalidLanguage',
+          type: 'Literal',
+          column: 46,
+          endColumn: 58,
           endLine: 1,
           line: 1,
         },
@@ -180,6 +295,44 @@ ruleTester.run('require-meta-languages', rule, {
       errors: [
         {
           messageId: 'invalid',
+          type: 'Identifier',
+          column: 30,
+          endColumn: 35,
+          endLine: 4,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        const langs = ['js'];
+        module.exports = {
+          meta: { languages: langs },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'invalidLanguage',
+          type: 'Identifier',
+          column: 30,
+          endColumn: 35,
+          endLine: 4,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        const langs = ['js/js', 'js/js'];
+        module.exports = {
+          meta: { languages: langs },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'duplicate',
           type: 'Identifier',
           column: 30,
           endColumn: 35,

--- a/tests/lib/rules/require-meta-languages.ts
+++ b/tests/lib/rules/require-meta-languages.ts
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview require rules to implement a `meta.languages` property
+ * @author morgan-coded
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import rule from '../../../lib/rules/require-meta-languages.ts';
+import { RuleTester } from 'eslint';
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  languageOptions: { sourceType: 'commonjs' },
+});
+ruleTester.run('require-meta-languages', rule, {
+  valid: [
+    "module.exports = { meta: { languages: ['js/js'] }, create(context) {} };",
+    "module.exports = { meta: { languages: ['js/js', 'json/json'] }, create(context) {} };",
+    'module.exports = { meta: { languages: someVar }, create(context) {} };',
+    `
+      const baseRule = require('./base-rule');
+      module.exports = {
+        meta: { ...baseRule.meta },
+        create(context) {}
+      };
+    `,
+    'const x = 5;',
+  ],
+
+  invalid: [
+    {
+      code: `
+        module.exports = {
+          meta: { type: 'problem' },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          column: 17,
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = { create(context) {} };',
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'FunctionExpression',
+          column: 26,
+          endColumn: 38,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = { meta: { languages: [] }, create(context) {} };',
+      errors: [
+        {
+          messageId: 'empty',
+          type: 'ArrayExpression',
+          column: 39,
+          endColumn: 41,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: 'js/js' }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalid',
+          type: 'Literal',
+          column: 39,
+          endColumn: 46,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "module.exports = { meta: { languages: ['js/js', 123] }, create(context) {} };",
+      errors: [
+        {
+          messageId: 'invalid',
+          type: 'ArrayExpression',
+          column: 39,
+          endColumn: 53,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/tests/lib/rules/require-meta-languages.ts
+++ b/tests/lib/rules/require-meta-languages.ts
@@ -20,8 +20,32 @@ const ruleTester = new RuleTester({
 ruleTester.run('require-meta-languages', rule, {
   valid: [
     "module.exports = { meta: { languages: ['js/js'] }, create(context) {} };",
+    {
+      // ESM
+      code: `
+        export default {
+          meta: { languages: ['js/js'] },
+          create(context) {}
+        };
+      `,
+      languageOptions: { sourceType: 'module' },
+    },
     "module.exports = { meta: { languages: ['js/js', 'json/json'] }, create(context) {} };",
     'module.exports = { meta: { languages: someVar }, create(context) {} };',
+    `
+      const extra = { languages: ['js/js'] };
+      module.exports = {
+        meta: { ...extra },
+        create(context) {}
+      };
+    `,
+    `
+      const langs = ['js/js'];
+      module.exports = {
+        meta: { languages: langs },
+        create(context) {}
+      };
+    `,
     `
       const baseRule = require('./base-rule');
       module.exports = {
@@ -29,7 +53,15 @@ ruleTester.run('require-meta-languages', rule, {
         create(context) {}
       };
     `,
-    'const x = 5;',
+    'module.exports = {};', // No rule.
+    // No `create` function.
+    `
+        const create = {};
+        module.exports = {
+          meta: { languages: ['js/js'] },
+          create,
+        };
+      `,
   ],
 
   invalid: [
@@ -59,6 +91,40 @@ ruleTester.run('require-meta-languages', rule, {
           type: 'FunctionExpression',
           column: 26,
           endColumn: 38,
+          endLine: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      // ESM
+      code: `
+        export default {
+          meta: {},
+          create(context) {}
+        };
+      `,
+      languageOptions: { sourceType: 'module' },
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          column: 17,
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      // `meta` in variable, missing `languages`.
+      code: 'const meta = {}; module.exports = { meta, create(context) {} };',
+      errors: [
+        {
+          messageId: 'missing',
+          type: 'ObjectExpression',
+          column: 14,
+          endColumn: 16,
           endLine: 1,
           line: 1,
         },
@@ -100,6 +166,61 @@ ruleTester.run('require-meta-languages', rule, {
           endColumn: 53,
           endLine: 1,
           line: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        const langs = 'js/js';
+        module.exports = {
+          meta: { languages: langs },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'invalid',
+          type: 'Identifier',
+          column: 30,
+          endColumn: 35,
+          endLine: 4,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { languages: null },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'invalid',
+          type: 'Literal',
+          column: 30,
+          endColumn: 34,
+          endLine: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        module.exports = {
+          meta: { languages: undefined },
+          create(context) {}
+        };
+      `,
+      errors: [
+        {
+          messageId: 'invalid',
+          type: 'Identifier',
+          column: 30,
+          endColumn: 39,
+          endLine: 3,
+          line: 3,
         },
       ],
     },


### PR DESCRIPTION
**What changed:** Adds a new `require-meta-languages` rule for the `meta.languages` property introduced in ESLint v10.2.0, reporting absent properties, empty arrays, and values that are not arrays of strings while skipping dynamic values and unresolved `meta` spreads that cannot be inspected statically.

Registers the rule in `lib/index.ts` and adds its rule doc plus the README row generated by `eslint-doc-generator`; it stays out of `recommended` because enabling it there is a breaking change deferred to #538.

**ESLint 9 compatibility:** As agreed on #614, keeps the rule off for this plugin's own files in `eslint.config.ts` because the plugin still supports ESLint 9, whose rule metadata types do not include `meta.languages`; it can be enabled there once the minimum ESLint version reaches 10.2.

**Testing:** Unit tests cover absent, empty, invalid, unresolved, and valid values, and the full suite passes with 1,244 tests and 98.3% statement, 96.05% branch, 99.17% function, and 98.44% line coverage.

Manual validation also ran the built rule against `eslint-plugin-n` 18.2.2, `eslint-plugin-unicorn` 72.0.0, and `eslint-plugin-promise` 7.3.0; all three runs were crash-free, the unresolved `meta` spread in `eslint-plugin-n` was skipped, and Unicorn rules already declaring `languages: ['js/js']` passed.

Closes #614

Closes #645
