### PR TITLE
fix: string array schema validation for `meta-property-ordering` and `test-case-property-ordering` rules

### DIFF
--- a/lib/rules/meta-property-ordering.ts
+++ b/lib/rules/meta-property-ordering.ts
@@ -37,7 +37,7 @@ const rule: Rule.RuleModule = {
       {
         type: 'array',
         description: 'What order to enforce for meta properties.',
-        elements: { type: 'string' },
+        items: { type: 'string' },
       },
     ],
     defaultOptions: [defaultOrder],

--- a/lib/rules/test-case-property-ordering.ts
+++ b/lib/rules/test-case-property-ordering.ts
@@ -40,7 +40,7 @@ const rule: Rule.RuleModule = {
       {
         type: 'array',
         description: 'What order to enforce for test case properties.',
-        elements: { type: 'string' },
+        items: { type: 'string' },
       },
     ],
     defaultOptions: [defaultOrder],

--- a/tests/lib/schema-array-item-options.ts
+++ b/tests/lib/schema-array-item-options.ts
@@ -1,0 +1,45 @@
+import { Linter, type Rule } from 'eslint';
+import { describe, it, expect } from 'vitest';
+import metaPropertyOrdering from '../../lib/rules/meta-property-ordering.ts';
+import testCasePropertyOrdering from '../../lib/rules/test-case-property-ordering.ts';
+
+const linter = new Linter();
+
+function invalidOptionConfig(
+  ruleName: string,
+  rule: Rule.RuleModule,
+  option: unknown,
+): Linter.Config {
+  return {
+    plugins: { test: { rules: { [ruleName]: rule } } },
+    rules: { [`test/${ruleName}`]: ['error', option] as Linter.RuleEntry },
+  };
+}
+
+describe('array option schemas reject non-string items', () => {
+  it('meta-property-ordering', () => {
+    expect(() =>
+      linter.verify(
+        'foo;',
+        invalidOptionConfig(
+          'meta-property-ordering',
+          metaPropertyOrdering,
+          [1, 2, 3],
+        ),
+      ),
+    ).toThrow(/should be string/i);
+  });
+
+  it('test-case-property-ordering', () => {
+    expect(() =>
+      linter.verify(
+        'foo;',
+        invalidOptionConfig(
+          'test-case-property-ordering',
+          testCasePropertyOrdering,
+          [1, 2, 3],
+        ),
+      ),
+    ).toThrow(/should be string/i);
+  });
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Bug fix. `meta-property-ordering` and `test-case-property-ordering` declared their string-array `order` option with the JTD keyword `elements` instead of the JSON Schema keyword `items`. ESLint validates options with JSON Schema (via ajv), so `elements` was silently ignored and the "each item is a string" constraint was never enforced (e.g. `["error", [1, 2, 3]]` was accepted).

#### What changes did you make? (Give an overview)

Switch to `items` and add a regression test asserting non-string values are now rejected.

`no-property-in-node` uses the same mistaken keyword, but its existing tests pass regex literals for `additionalNodeTypeFiles` (the option is typed as `string[]` and each value is passed to `new RegExp()`), so switching it to `items` also requires updating those tests. That's already handled in #648, so it's intentionally left out here.

#### Related Issues

Fixes #649

#### Is there anything you'd like reviewers to focus on?

The regression test uses `Linter` directly rather than `RuleTester`, because `RuleTester.run()` invokes the test framework's `describe`/`it` internally and so can't be wrapped in `expect(...).toThrow()` to assert that an invalid option is rejected.