### PR TITLE
fix: port `schema`/`deprecated` in prefer-object-rule

### DIFF
--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -46,3 +46,26 @@ module.exports = {
   },
 };
 ```
+
+When autofixing, any `schema` or `deprecated` properties that the deprecated function-style format exposed directly on the exported function are ported over into the `meta` object.
+
+Before:
+
+```js
+module.exports = function create(context) {
+  return {/* ... */};
+};
+module.exports.schema = [{/* options */}];
+module.exports.deprecated = true;
+```
+
+After:
+
+```js
+module.exports = {
+  meta: { schema: [{/* options */}], deprecated: true },
+  create(context) {
+    return {/* ... */};
+  },
+};
+```

--- a/docs/rules/prefer-object-rule.md
+++ b/docs/rules/prefer-object-rule.md
@@ -49,6 +49,8 @@ module.exports = {
 
 When autofixing, any `schema` or `deprecated` properties that the deprecated function-style format exposed directly on the exported function are ported over into the `meta` object.
 
+Static values (literals, or arrays/objects of literals) are inlined directly into `meta`:
+
 Before:
 
 ```js
@@ -68,4 +70,27 @@ module.exports = {
     return {/* ... */};
   },
 };
+```
+
+A value that can't be safely relocated — for example, one that references a variable or has side effects — is instead reassigned onto `meta` in place, so its evaluation order and any side effects are preserved:
+
+Before:
+
+```js
+module.exports = function create(context) {
+  return {/* ... */};
+};
+module.exports.schema = getSchema();
+```
+
+After:
+
+```js
+module.exports = {
+  meta: {},
+  create(context) {
+    return {/* ... */};
+  },
+};
+module.exports.meta.schema = getSchema();
 ```

--- a/lib/rules/prefer-object-rule.ts
+++ b/lib/rules/prefer-object-rule.ts
@@ -8,17 +8,17 @@ import { getRuleInfo } from '../utils.ts';
 
 const META_PROPERTIES_TO_PORT = new Set(['schema', 'deprecated']);
 
-type PortableMetaAssignment = {
+type MetaAssignment = {
   key: string;
   valueNode: Expression;
 };
 
-type PortableMetaResult = {
-  properties: PortableMetaAssignment[];
+type CollectedMetaAssignments = {
+  properties: MetaAssignment[];
   statementsToRemove: Node[];
 };
 
-function getPortableMetaAssignments(program: Program): PortableMetaResult {
+function collectMetaAssignments(program: Program): CollectedMetaAssignments {
   const propertiesByKey = new Map<string, Expression>();
   const statementsToRemove: Node[] = [];
   let exportsVarOverridden = false;
@@ -84,7 +84,7 @@ function getPortableMetaAssignments(program: Program): PortableMetaResult {
 }
 
 function buildMetaPrefix(
-  properties: PortableMetaAssignment[],
+  properties: MetaAssignment[],
   sourceCode: SourceCode,
 ): string {
   if (properties.length === 0) {
@@ -131,7 +131,7 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        const { properties, statementsToRemove } = getPortableMetaAssignments(
+        const { properties, statementsToRemove } = collectMetaAssignments(
           sourceCode.ast,
         );
         const metaPrefix = buildMetaPrefix(properties, sourceCode);

--- a/lib/rules/prefer-object-rule.ts
+++ b/lib/rules/prefer-object-rule.ts
@@ -11,13 +11,17 @@ const META_PROPERTIES_TO_PORT = new Set(['schema', 'deprecated']);
 type PortableMetaAssignment = {
   key: string;
   valueNode: Expression;
-  statement: Node;
 };
 
-function getPortableMetaAssignments(
-  program: Program,
-): PortableMetaAssignment[] {
-  const results: PortableMetaAssignment[] = [];
+type PortableMetaResult = {
+  properties: PortableMetaAssignment[];
+  statementsToRemove: Node[];
+};
+
+function getPortableMetaAssignments(program: Program): PortableMetaResult {
+  const propertiesByKey = new Map<string, Expression>();
+  const statementsToRemove: Node[] = [];
+  let exportsVarOverridden = false;
   let hasExistingMetaAssignment = false;
 
   for (const statement of program.body) {
@@ -32,9 +36,22 @@ function getPortableMetaAssignments(
       continue;
     }
     const leftExpression = expression.left;
+    if (leftExpression.type !== 'MemberExpression' || leftExpression.computed) {
+      continue;
+    }
+
     if (
-      leftExpression.type !== 'MemberExpression' ||
-      leftExpression.computed ||
+      leftExpression.object.type === 'Identifier' &&
+      leftExpression.object.name === 'module' &&
+      leftExpression.property.type === 'Identifier' &&
+      leftExpression.property.name === 'exports'
+    ) {
+      exportsVarOverridden = true;
+      continue;
+    }
+
+    if (
+      !exportsVarOverridden ||
       leftExpression.object.type !== 'MemberExpression' ||
       leftExpression.object.computed ||
       leftExpression.object.object.type !== 'Identifier' ||
@@ -50,27 +67,36 @@ function getPortableMetaAssignments(
     if (key === 'meta') {
       hasExistingMetaAssignment = true;
     } else if (META_PROPERTIES_TO_PORT.has(key)) {
-      results.push({ key, valueNode: expression.right, statement });
+      propertiesByKey.set(key, expression.right);
+      statementsToRemove.push(statement);
     }
   }
 
-  return hasExistingMetaAssignment ? [] : results;
+  if (hasExistingMetaAssignment) {
+    return { properties: [], statementsToRemove: [] };
+  }
+
+  const properties = [...propertiesByKey].map(([key, valueNode]) => ({
+    key,
+    valueNode,
+  }));
+  return { properties, statementsToRemove };
 }
 
 function buildMetaPrefix(
-  assignments: PortableMetaAssignment[],
+  properties: PortableMetaAssignment[],
   sourceCode: SourceCode,
 ): string {
-  if (assignments.length === 0) {
+  if (properties.length === 0) {
     return '';
   }
-  const properties = assignments
+  const text = properties
     .map(
-      (assignment) =>
-        `${assignment.key}: ${sourceCode.getText(assignment.valueNode)}`,
+      (property) =>
+        `${property.key}: ${sourceCode.getText(property.valueNode)}`,
     )
     .join(', ');
-  return `meta: {${properties}}, `;
+  return `meta: {${text}}, `;
 }
 
 // ------------------------------------------------------------------------------
@@ -105,8 +131,10 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        const metaAssignments = getPortableMetaAssignments(sourceCode.ast);
-        const metaPrefix = buildMetaPrefix(metaAssignments, sourceCode);
+        const { properties, statementsToRemove } = getPortableMetaAssignments(
+          sourceCode.ast,
+        );
+        const metaPrefix = buildMetaPrefix(properties, sourceCode);
 
         context.report({
           node: ruleInfo.create,
@@ -142,8 +170,8 @@ const rule: Rule.RuleModule = {
               yield fixer.insertTextAfter(ruleInfo.create, '}');
             }
 
-            for (const assignment of metaAssignments) {
-              yield fixer.remove(assignment.statement);
+            for (const statement of statementsToRemove) {
+              yield fixer.remove(statement);
             }
           },
         });

--- a/lib/rules/prefer-object-rule.ts
+++ b/lib/rules/prefer-object-rule.ts
@@ -2,7 +2,7 @@
  * @author Brad Zacher <https://github.com/bradzacher>
  */
 import type { Rule, SourceCode } from 'eslint';
-import type { Expression, Node, Program } from 'estree';
+import type { AssignmentExpression, Expression, Node, Program } from 'estree';
 
 import { getRuleInfo } from '../utils.ts';
 
@@ -10,21 +10,97 @@ const META_PROPERTIES_TO_PORT = new Set(['schema', 'deprecated']);
 
 type MetaAssignment = {
   key: string;
+  statement: Node;
+  memberObject: Node;
   valueNode: Expression;
 };
 
-type CollectedMetaAssignments = {
-  properties: MetaAssignment[];
-  statementsToRemove: Node[];
+type MetaFix = {
+  inline: MetaAssignment[];
+  remove: Node[];
+  rewrite: MetaAssignment[];
 };
 
-function collectMetaAssignments(program: Program): CollectedMetaAssignments {
-  const propertiesByKey = new Map<string, Expression>();
-  const statementsToRemove: Node[] = [];
-  let exportsVarOverridden = false;
+// Only static values are safe to inline into `meta`. Non-static ones are rewritten in place.
+function isStaticExpression(node: Node): boolean {
+  switch (node.type) {
+    case 'Literal': {
+      return true;
+    }
+    case 'UnaryExpression': {
+      return (
+        (node.operator === '-' || node.operator === '+') &&
+        isStaticExpression(node.argument)
+      );
+    }
+    case 'ArrayExpression': {
+      return node.elements.every(
+        (element) => element !== null && isStaticExpression(element),
+      );
+    }
+    case 'ObjectExpression': {
+      return node.properties.every(
+        (property) =>
+          property.type === 'Property' &&
+          !property.computed &&
+          isStaticExpression(property.value),
+      );
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function getModuleExportsAssignment(
+  statement: Node,
+): AssignmentExpression | undefined {
+  if (statement.type !== 'ExpressionStatement') {
+    return undefined;
+  }
+  const expression = statement.expression;
+  if (
+    expression.type !== 'AssignmentExpression' ||
+    expression.operator !== '='
+  ) {
+    return undefined;
+  }
+  const left = expression.left;
+  if (
+    left.type === 'MemberExpression' &&
+    !left.computed &&
+    left.object.type === 'Identifier' &&
+    left.object.name === 'module' &&
+    left.property.type === 'Identifier' &&
+    left.property.name === 'exports'
+  ) {
+    return expression;
+  }
+  return undefined;
+}
+
+function collectMetaAssignments(program: Program, createNode: Node): MetaFix {
+  const empty: MetaFix = { inline: [], remove: [], rewrite: [] };
+
+  const exportIndex = program.body.findIndex((statement) => {
+    const assignment = getModuleExportsAssignment(statement);
+    return assignment !== undefined && assignment.right === createNode;
+  });
+  if (exportIndex === -1) {
+    return empty;
+  }
+
+  const collectedByKey = new Map<string, MetaAssignment[]>();
   let hasExistingMetaAssignment = false;
 
-  for (const statement of program.body) {
+  for (let index = exportIndex + 1; index < program.body.length; index++) {
+    const statement = program.body[index];
+    // Stop at the next `module.exports =`. `getRuleInfo` resolves the last one,
+    // so this should not be reachable, but it keeps the scan bounded if that changes.
+    /* istanbul ignore if */
+    if (getModuleExportsAssignment(statement)) {
+      break;
+    }
     if (statement.type !== 'ExpressionStatement') {
       continue;
     }
@@ -35,68 +111,72 @@ function collectMetaAssignments(program: Program): CollectedMetaAssignments {
     ) {
       continue;
     }
-    const leftExpression = expression.left;
-    if (leftExpression.type !== 'MemberExpression' || leftExpression.computed) {
-      continue;
-    }
-
+    const left = expression.left;
     if (
-      leftExpression.object.type === 'Identifier' &&
-      leftExpression.object.name === 'module' &&
-      leftExpression.property.type === 'Identifier' &&
-      leftExpression.property.name === 'exports'
-    ) {
-      exportsVarOverridden = true;
-      continue;
-    }
-
-    if (
-      !exportsVarOverridden ||
-      leftExpression.object.type !== 'MemberExpression' ||
-      leftExpression.object.computed ||
-      leftExpression.object.object.type !== 'Identifier' ||
-      leftExpression.object.object.name !== 'module' ||
-      leftExpression.object.property.type !== 'Identifier' ||
-      leftExpression.object.property.name !== 'exports' ||
-      leftExpression.property.type !== 'Identifier'
+      left.type !== 'MemberExpression' ||
+      left.computed ||
+      left.object.type !== 'MemberExpression' ||
+      left.object.computed ||
+      left.object.object.type !== 'Identifier' ||
+      left.object.object.name !== 'module' ||
+      left.object.property.type !== 'Identifier' ||
+      left.object.property.name !== 'exports' ||
+      left.property.type !== 'Identifier'
     ) {
       continue;
     }
 
-    const key = leftExpression.property.name;
+    const key = left.property.name;
     if (key === 'meta') {
       hasExistingMetaAssignment = true;
     } else if (META_PROPERTIES_TO_PORT.has(key)) {
-      propertiesByKey.set(key, expression.right);
-      statementsToRemove.push(statement);
+      const entry: MetaAssignment = {
+        key,
+        statement,
+        memberObject: left.object,
+        valueNode: expression.right,
+      };
+      const existing = collectedByKey.get(key);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        collectedByKey.set(key, [entry]);
+      }
     }
   }
 
   if (hasExistingMetaAssignment) {
-    return { properties: [], statementsToRemove: [] };
+    return empty;
   }
 
-  const properties = [...propertiesByKey].map(([key, valueNode]) => ({
-    key,
-    valueNode,
-  }));
-  return { properties, statementsToRemove };
+  const fix: MetaFix = { inline: [], remove: [], rewrite: [] };
+  for (const entries of collectedByKey.values()) {
+    if (entries.every((entry) => isStaticExpression(entry.valueNode))) {
+      fix.inline.push(entries.at(-1)!);
+      for (const entry of entries) {
+        fix.remove.push(entry.statement);
+      }
+    } else {
+      fix.rewrite.push(...entries);
+    }
+  }
+  return fix;
 }
 
-function buildMetaPrefix(
-  properties: MetaAssignment[],
-  sourceCode: SourceCode,
-): string {
-  if (properties.length === 0) {
-    return '';
+function buildMetaPrefix(fix: MetaFix, sourceCode: SourceCode): string {
+  if (fix.inline.length > 0) {
+    const text = fix.inline
+      .map(
+        (assignment) =>
+          `${assignment.key}: ${sourceCode.getText(assignment.valueNode)}`,
+      )
+      .join(', ');
+    return `meta: {${text}}, `;
   }
-  const text = properties
-    .map(
-      (property) =>
-        `${property.key}: ${sourceCode.getText(property.valueNode)}`,
-    )
-    .join(', ');
-  return `meta: {${text}}, `;
+  if (fix.rewrite.length > 0) {
+    return 'meta: {}, ';
+  }
+  return '';
 }
 
 // ------------------------------------------------------------------------------
@@ -131,10 +211,8 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        const { properties, statementsToRemove } = collectMetaAssignments(
-          sourceCode.ast,
-        );
-        const metaPrefix = buildMetaPrefix(properties, sourceCode);
+        const metaFix = collectMetaAssignments(sourceCode.ast, ruleInfo.create);
+        const metaPrefix = buildMetaPrefix(metaFix, sourceCode);
 
         context.report({
           node: ruleInfo.create,
@@ -170,8 +248,11 @@ const rule: Rule.RuleModule = {
               yield fixer.insertTextAfter(ruleInfo.create, '}');
             }
 
-            for (const statement of statementsToRemove) {
+            for (const statement of metaFix.remove) {
               yield fixer.remove(statement);
+            }
+            for (const assignment of metaFix.rewrite) {
+              yield fixer.insertTextAfter(assignment.memberObject, '.meta');
             }
           },
         });

--- a/lib/rules/prefer-object-rule.ts
+++ b/lib/rules/prefer-object-rule.ts
@@ -1,9 +1,77 @@
 /**
  * @author Brad Zacher <https://github.com/bradzacher>
  */
-import type { Rule } from 'eslint';
+import type { Rule, SourceCode } from 'eslint';
+import type { Expression, Node, Program } from 'estree';
 
 import { getRuleInfo } from '../utils.ts';
+
+const META_PROPERTIES_TO_PORT = new Set(['schema', 'deprecated']);
+
+type PortableMetaAssignment = {
+  key: string;
+  valueNode: Expression;
+  statement: Node;
+};
+
+function getPortableMetaAssignments(
+  program: Program,
+): PortableMetaAssignment[] {
+  const results: PortableMetaAssignment[] = [];
+  let hasExistingMetaAssignment = false;
+
+  for (const statement of program.body) {
+    if (statement.type !== 'ExpressionStatement') {
+      continue;
+    }
+    const expression = statement.expression;
+    if (
+      expression.type !== 'AssignmentExpression' ||
+      expression.operator !== '='
+    ) {
+      continue;
+    }
+    const leftExpression = expression.left;
+    if (
+      leftExpression.type !== 'MemberExpression' ||
+      leftExpression.computed ||
+      leftExpression.object.type !== 'MemberExpression' ||
+      leftExpression.object.computed ||
+      leftExpression.object.object.type !== 'Identifier' ||
+      leftExpression.object.object.name !== 'module' ||
+      leftExpression.object.property.type !== 'Identifier' ||
+      leftExpression.object.property.name !== 'exports' ||
+      leftExpression.property.type !== 'Identifier'
+    ) {
+      continue;
+    }
+
+    const key = leftExpression.property.name;
+    if (key === 'meta') {
+      hasExistingMetaAssignment = true;
+    } else if (META_PROPERTIES_TO_PORT.has(key)) {
+      results.push({ key, valueNode: expression.right, statement });
+    }
+  }
+
+  return hasExistingMetaAssignment ? [] : results;
+}
+
+function buildMetaPrefix(
+  assignments: PortableMetaAssignment[],
+  sourceCode: SourceCode,
+): string {
+  if (assignments.length === 0) {
+    return '';
+  }
+  const properties = assignments
+    .map(
+      (assignment) =>
+        `${assignment.key}: ${sourceCode.getText(assignment.valueNode)}`,
+    )
+    .join(', ');
+  return `meta: {${properties}}, `;
+}
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -37,6 +105,9 @@ const rule: Rule.RuleModule = {
           return;
         }
 
+        const metaAssignments = getPortableMetaAssignments(sourceCode.ast);
+        const metaPrefix = buildMetaPrefix(metaAssignments, sourceCode);
+
         context.report({
           node: ruleInfo.create,
           messageId: 'preferObject',
@@ -60,12 +131,19 @@ const rule: Rule.RuleModule = {
 
               yield fixer.replaceTextRange(
                 [ruleInfo.create.range[0], openParenToken.range[0]],
-                '{create',
+                `{${metaPrefix}create`,
               );
               yield fixer.insertTextAfter(ruleInfo.create, '}');
             } else if (ruleInfo.create.type === 'ArrowFunctionExpression') {
-              yield fixer.insertTextBefore(ruleInfo.create, '{create: ');
+              yield fixer.insertTextBefore(
+                ruleInfo.create,
+                `{${metaPrefix}create: `,
+              );
               yield fixer.insertTextAfter(ruleInfo.create, '}');
+            }
+
+            for (const assignment of metaAssignments) {
+              yield fixer.remove(assignment.statement);
             }
           },
         });

--- a/tests/lib/rules/prefer-object-rule.ts
+++ b/tests/lib/rules/prefer-object-rule.ts
@@ -227,5 +227,91 @@ ruleTester.run('prefer-object-rule', rule, {
         },
       ],
     },
+
+    {
+      code: "module.exports = function (context) { return {}; };\nmodule.exports.schema = [{ type: 'object' }];\nmodule.exports.deprecated = true;",
+      output:
+        "module.exports = {meta: {schema: [{ type: 'object' }], deprecated: true}, create(context) { return {}; }};\n\n",
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = (context) => { return {}; };\nmodule.exports.schema = [];',
+      output:
+        'module.exports = {meta: {schema: []}, create: (context) => { return {}; }};\n',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 45,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nexports.deprecated = true;',
+      output:
+        'module.exports = {create(context) { return {}; }};\nexports.deprecated = true;',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+
+    {
+      code: "module.exports = function (context) { return {}; };\nmodule.exports.fixable = 'code';\nmodule.exports['schema'] = [];",
+      output:
+        "module.exports = {create(context) { return {}; }};\nmodule.exports.fixable = 'code';\nmodule.exports['schema'] = [];",
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\ndoSomething();',
+      output:
+        'module.exports = {create(context) { return {}; }};\ndoSomething();',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = [1];\nmodule.exports.meta = {};',
+      output:
+        'module.exports = {create(context) { return {}; }};\nmodule.exports.schema = [1];\nmodule.exports.meta = {};',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
   ],
 });

--- a/tests/lib/rules/prefer-object-rule.ts
+++ b/tests/lib/rules/prefer-object-rule.ts
@@ -341,5 +341,131 @@ ruleTester.run('prefer-object-rule', rule, {
         },
       ],
     },
+    {
+      code: "module.exports = function (context) { return {}; };\nconst schema = [{ type: 'object' }];\nmodule.exports.schema = schema;",
+      output:
+        "module.exports = {meta: {}, create(context) { return {}; }};\nconst schema = [{ type: 'object' }];\nmodule.exports.meta.schema = schema;",
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = (foo(), []);',
+      output:
+        'module.exports = {meta: {}, create(context) { return {}; }};\nmodule.exports.meta.schema = (foo(), []);',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = someVar;\nmodule.exports.schema = [1];',
+      output:
+        'module.exports = {meta: {}, create(context) { return {}; }};\nmodule.exports.meta.schema = someVar;\nmodule.exports.meta.schema = [1];',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = getSchema();\nmodule.exports.schema = [1];',
+      output:
+        'module.exports = {meta: {}, create(context) { return {}; }};\nmodule.exports.meta.schema = getSchema();\nmodule.exports.meta.schema = [1];',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = getSchema();\nmodule.exports.deprecated = true;',
+      output:
+        'module.exports = {meta: {deprecated: true}, create(context) { return {}; }};\nmodule.exports.meta.schema = getSchema();\n',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: "module.exports = function (context) { return {}; };\nmodule.exports.schema = [{ type: 'integer', minimum: -1, maximum: +1 }];",
+      output:
+        "module.exports = {meta: {schema: [{ type: 'integer', minimum: -1, maximum: +1 }]}, create(context) { return {}; }};\n",
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = [1];\nmodule.exports = function (context) { return {}; };',
+      output:
+        'module.exports = function (context) { return {}; };\nmodule.exports.schema = [1];\nmodule.exports = {create(context) { return {}; }};',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 3,
+          column: 18,
+          endLine: 3,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.meta = {};\nmodule.exports = function (context) { return {}; };\nmodule.exports.schema = [1];',
+      output:
+        'module.exports = function (context) { return {}; };\nmodule.exports.meta = {};\nmodule.exports = {meta: {schema: [1]}, create(context) { return {}; }};\n',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 3,
+          column: 18,
+          endLine: 3,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'const rule = (context) => { return {}; };\nmodule.exports = rule;\nmodule.exports.schema = [1];',
+      output:
+        'const rule = {create: (context) => { return {}; }};\nmodule.exports = rule;\nmodule.exports.schema = [1];',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 14,
+          endLine: 1,
+          endColumn: 41,
+        },
+      ],
+    },
   ],
 });

--- a/tests/lib/rules/prefer-object-rule.ts
+++ b/tests/lib/rules/prefer-object-rule.ts
@@ -313,5 +313,33 @@ ruleTester.run('prefer-object-rule', rule, {
         },
       ],
     },
+    {
+      code: 'module.exports = function (context) { return {}; };\nmodule.exports.schema = [1];\nmodule.exports.schema = [2];',
+      output:
+        'module.exports = {meta: {schema: [2]}, create(context) { return {}; }};\n\n',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 51,
+        },
+      ],
+    },
+    {
+      code: 'module.exports.schema = [1];\nmodule.exports = function (context) { return {}; };',
+      output:
+        'module.exports.schema = [1];\nmodule.exports = {create(context) { return {}; }};',
+      errors: [
+        {
+          messageId: 'preferObject',
+          line: 2,
+          column: 18,
+          endLine: 2,
+          endColumn: 51,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint Community adheres to the [Open JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello. The `prefer-object-rule` rule automatically converts function-style rules into the object style, but in this process the existing fixer only wrapped the function as `{ create(…) {} }`, and assignments like `module.exports.schema` / `module.exports.deprecated` were attached at the top level, so ESLint could not recognize them as `meta.schema` and ignored them. This PR fixes that problem. Please see issue #311 for details.

#### What changes did you make? (Give an overview)

(1) I fixed the problem where the fixer only wrapped the function.

- I declared the assignments that can be moved into `meta` as `MetaAssignment`. (The reason I chose `type` instead of `interface` is that I followed the convention of the same folder.)
- The `collectMetaAssignments` function is a function that finds assignments and collects them so they can be moved into `meta`.
- It goes through `program.body` and, via an if statement, filters only the ones that satisfy the conditions (the code shape follows `getRuleExportsCJS` in `lib/utils.ts`, including its `exportsVarOverridden` handling). Then it returns the properties to port together with the statements to remove.
- After that, if there is a target to insert, it becomes the form `{meta: {…}, create …}`.
- If there is no target to insert, `metaPrefix` is `""`, so it becomes the form `{create …}`. This is exactly the same as before.
- Now the values have been organized and copied into `meta`. It removes the original `module.exports.schema`, `module.exports.deprecated` lines that were there.

(2) I added eight tests.

- It catches the function (`function`) form.
  - It catches `module.exports = function (context) { return {}; }`,
  - and moves `module.exports.schema` / `module.exports.deprecated` together,
  - and changes it into `{meta: {schema: [{ type: 'object' }], deprecated: true}, create(context) { return {}; }}`.
  - (checks that when there are multiple properties they are joined with commas inside `meta`)
- It catches the arrow function (`=>`) form.
  - It catches `module.exports = (context) => { return {}; }`,
  - and changes it into `{meta: {schema: []}, create: (context) => { return {}; }}`.
  - (also checks the case where only `schema` is present)
- `exports.<key>` is left untouched (it is not ported).
  - `exports.deprecated = true` is not moved, because in a function-style rule the `exports` binding no longer refers to the exported rule (so it is dead code),
  - and only the function is wrapped, as in `module.exports = {create(context) { return {}; }};`, leaving `exports.deprecated = true` as it was.
- Non-target keys and computed (bracket) accesses are not moved into `meta`; they are left as is.
  - `module.exports.fixable = 'code'` (a key other than schema/deprecated) or `module.exports['schema'] = []` (bracket access, not dot access) are not ported,
  - and only the function is wrapped, as in `module.exports = {create(context) { return {}; }};`, leaving those assignments as they were.
- Top-level statements unrelated to the fixer are left untouched.
  - statements like `doSomething();` are not touched,
  - and only the function is wrapped, as in `{create(context) { return {}; }}`.
- If `module.exports.meta` is already assigned, nothing is ported (so it cannot clobber the injected `meta`).
  - for `module.exports.schema = [1];` alongside `module.exports.meta = {};`, the fixer only wraps the function and leaves both assignments as they were.
- When the same property is assigned more than once, the last assignment wins and no duplicate key is produced.
  - `module.exports.schema = [1]; module.exports.schema = [2];` becomes `{meta: {schema: [2]}, create(context) { return {}; }}`, and both original lines are removed.
- An assignment placed before `module.exports = function ...` is dead code (the reassignment discards it), so it is not ported.
  - `module.exports.schema = [1];` written before `module.exports = function (context) { return {}; };` is left as it was, and only the function is wrapped.

(3) I added a section to the rule's documentation.

- The existing example (function style -> object style) is meant to explain the rule, so I left it as is, and since the `schema`/`deprecated` porting I worked on this time is a separate detailed behavior of the fixer, I added it as a new section.

#### Related Issues

fixes #311

#### Is there anything you'd like reviewers to focus on?

Since this fixes the existing fixer's unintended behavior, it was written with the `fix` prefix. However, since it changes the existing behavior, I think the `feat` prefix could also be valid!
